### PR TITLE
Add support for letter templates in the integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.3.0] - 2017-08-09
+## Changed
+
+* Update integration tests to support letter templates:
+
 ## [1.2.0] - 2017-05-11
 ## Changed
 

--- a/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
+++ b/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
@@ -265,17 +265,21 @@ namespace Notify.IntegrationTests
 		{
 			Assert.IsNotNull(notification.type);
 			String notificationType = notification.type;
-			String[] allowedNotificationTypes = { "email", "sms" };
+			String[] allowedNotificationTypes = { "email", "sms", "letter" };
 			CollectionAssert.Contains(allowedNotificationTypes, notificationType);
-			if (notificationType.Equals("sms"))
-			{
-				Assert.IsNotNull(notification.phoneNumber);
-			}
-			else if (notificationType.Equals("email"))
-			{
-				Assert.IsNotNull(notification.emailAddress);
-				Assert.IsNotNull(notification.subject);
-			}
+            if (notificationType.Equals("sms"))
+            {
+                Assert.IsNotNull(notification.phoneNumber);
+            }
+            else if (notificationType.Equals("email"))
+            {
+                Assert.IsNotNull(notification.emailAddress);
+                Assert.IsNotNull(notification.subject);
+            }
+            else if (notificationType.Equals("letter"))
+            {
+                Assert.IsNotNull(notification.subject);
+            }
 
 			Assert.IsNotNull(notification.body);
 			Assert.IsNotNull(notification.createdAt);

--- a/src/Notify/Properties/AssemblyInfo.cs
+++ b/src/Notify/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GOV.UK .NET Notify Client")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyVersion("1.3.0")]


### PR DESCRIPTION
This adds support for letter templates that are now included in our integration tests pipeline.

Version bump to `1.3.0`. 