### PR TITLE
Add template name to template response models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.4.0] - 2017-08-30
+## Changed
+
+* Add template name to `TemplateResponse` model
+
 ## [1.3.0] - 2017-08-09
 ## Changed
 

--- a/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
+++ b/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
@@ -309,6 +309,7 @@ namespace Notify.IntegrationTests
 		{
 			Assert.IsNotNull(template);
 			Assert.IsNotNull(template.id);
+            Assert.IsNotNull(template.name);
 			Assert.IsNotNull(template.version);
 			Assert.IsNotNull(template.type);
 			if (template.type.Equals("email") || (!string.IsNullOrEmpty(type) && type.Equals("email")))

--- a/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
+++ b/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
@@ -309,7 +309,7 @@ namespace Notify.IntegrationTests
 		{
 			Assert.IsNotNull(template);
 			Assert.IsNotNull(template.id);
-            Assert.IsNotNull(template.name);
+			Assert.IsNotNull(template.name);
 			Assert.IsNotNull(template.version);
 			Assert.IsNotNull(template.type);
 			if (template.type.Equals("email") || (!string.IsNullOrEmpty(type) && type.Equals("email")))

--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ If the request is successful, `response` will be a `TemplateResponse`:
 
 ```csharp
 public String id; 
+public String name;
 public String type;
 public DateTime created_at;
 public DateTime? updated_at;
@@ -542,6 +543,7 @@ If the request is successful, `response` will be a `TemplateResponse`:
 
 ```csharp
 public String id; 
+public String name;
 public String type;
 public DateTime created_at;
 public DateTime? updated_at;

--- a/src/Notify/Models/Responses/TemplatePreviewResponse.cs
+++ b/src/Notify/Models/Responses/TemplatePreviewResponse.cs
@@ -5,6 +5,7 @@ namespace Notify.Models.Responses
     public class TemplatePreviewResponse
     {
         public String id;
+        public String name;
         public String type;
         public int version;
         public String body;
@@ -14,6 +15,7 @@ namespace Notify.Models.Responses
         {
             return (
                 id == response.id &&
+                name == response.name &&
                 type == response.type &&
                 version == response.version &&
                 body == response.body &&

--- a/src/Notify/Models/Responses/TemplateResponse.cs
+++ b/src/Notify/Models/Responses/TemplateResponse.cs
@@ -5,6 +5,7 @@ namespace Notify.Models.Responses
     public class TemplateResponse
     {
         public String id;
+        public String name;
         public String type;
         public DateTime created_at;
         public DateTime? updated_at;
@@ -17,6 +18,7 @@ namespace Notify.Models.Responses
         {
             return (
                 id == response.id &&
+                name == response.name &&
                 type == response.type &&
                 created_at == response.created_at &&
                 updated_at == response.updated_at &&

--- a/src/Notify/Properties/AssemblyInfo.cs
+++ b/src/Notify/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0")]
+[assembly: AssemblyVersion("1.4.0")]


### PR DESCRIPTION
The public api has a pull request to include the name in template responses, this pull request adds the name property to the template response models so the new data is used.

Also, ignore the duplicate commit reference earlier, I hadn't set the email config on this machine... 🙂