### PR TITLE
Make personalisation nonnull when sending letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.5.1] - 2017-09-22
+## Changed
+
+* Make personalisation non-null in SendLetter
+
 ## [1.5.0] - 2017-09-22
 ## Changed
 

--- a/src/Notify/Client/NotificationClient.cs
+++ b/src/Notify/Client/NotificationClient.cs
@@ -124,7 +124,7 @@ namespace Notify.Client
             return receipt;
         }
 
-        public LetterNotificationResponse SendLetter(String templateId, Dictionary<String, dynamic> personalisation = null, String clientReference = null)
+        public LetterNotificationResponse SendLetter(String templateId, Dictionary<String, dynamic> personalisation, String clientReference = null)
         {
             JObject o = CreateRequestParams(templateId, personalisation, clientReference);
 

--- a/src/Notify/Properties/AssemblyInfo.cs
+++ b/src/Notify/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0")]
+[assembly: AssemblyVersion("1.5.1")]


### PR DESCRIPTION
This ensures the personalisation cannot be null when calling `SendLetter`.