### PR TITLE
Upgrade to .NET 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.5.3] - 2017-11-10
+## Changed
+
+* Upgraded both projects to .NET 4.7 and upgraded the dependencies to their latest version. The method with use in JWT has been deprecated so has stayed the same version.
+
 ## [1.5.2] - 2017-10-11
 ## Changed
 

--- a/NotifyTests/NotifyTests.csproj
+++ b/NotifyTests/NotifyTests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>NotifyTests</RootNamespace>
     <AssemblyName>NotifyTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,19 +30,45 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="Castle.Core">
-      <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
+      <Private>False</Private>
     </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="Moq">
-      <HintPath>..\packages\Moq.4.7.10\lib\net45\Moq.dll</HintPath>
+      <HintPath>..\packages\Moq.4.7.145\lib\net45\Moq.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="System.Net.Http" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.IO">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Security.Cryptography.Encoding">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IntegrationTests\NotificationIntegrationClientTests.cs" />

--- a/NotifyTests/packages.config
+++ b/NotifyTests/packages.config
@@ -1,8 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
-  <package id="Moq" version="4.7.10" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
+  <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
+  <package id="Moq" version="4.7.145" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
+  <package id="System.IO" version="4.3.0" targetFramework="net47" />
+  <package id="System.Net.Http" version="4.3.3" targetFramework="net452" requireReinstallation="true" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net47" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net47" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net47" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net47" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net47" />
 </packages>

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Notify</RootNamespace>
     <AssemblyName>Notify</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -43,7 +43,8 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="JWT">
       <HintPath>..\..\packages\JWT.2.4.1\lib\net35\JWT.dll</HintPath>

--- a/src/Notify/Notify.nuspec
+++ b/src/Notify/Notify.nuspec
@@ -12,8 +12,8 @@
     <copyright>Copyright 2016</copyright>
     <tags>Notify .NET-Client</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="9.0.1" />
-      <dependency id="JWT" version="1.3.4" />
+      <dependency id="Newtonsoft.Json" version="10.0.3" />
+      <dependency id="JWT" version="2.4.1" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Notify/Properties/AssemblyInfo.cs
+++ b/src/Notify/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.2")]
+[assembly: AssemblyVersion("1.5.3")]

--- a/src/Notify/packages.config
+++ b/src/Notify/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JWT" version="2.4.1" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="JWT" version="2.4.1" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
This involved upgrading all the other packages but not the JWT library as the method we use has been deprecated in later versions and will involve a code change.
