### PR TITLE
Add get received texts, sms_sender option and a Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ Notify.userprefs
 bin/
 obj/
 
+# Test results
+TestResult.xml
+
 # Linux and Mac Dev Environment
 environment.sh
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.6.0] - 2017-11-15
+## Changed
+
+* Update to `NotificationsClient.SendSms`
+    * added `smsSenderId`: an optional smsSenderId specified when adding a text message sender under service settings, if this is not provided it will default to the service name.
+* Added `GetReceivedTexts` - retrieves all received text messages, links provided with page size of 250
+* Added `Makefile` in order to run build, tests and nuget package from the terminal.
+
 ## [1.5.3] - 2017-11-15
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 ## [1.5.2] - 2017-10-11
 ## Changed
 
-* Update to `NotificationsAPIClient.send_email_notification()`
-    * added `email_reply_to_id`: an optional email_reply_to_id specified when adding Email reply to addresses under service settings, if this is not provided the reply to email will be the service default reply to email. `email_reply_to_id` can be omitted.
+* Update to `NotificationsClient.send_email_notification`
+    * added `emailReplyToId`: an optional emailReplyToId specified when adding Email reply to addresses under service settings, if this is not provided the reply to email will be the service default reply to email. `email_reply_to_id` can be omitted.
 
 ## [1.5.1] - 2017-09-22
 ## Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,4 +18,7 @@ FUNCTIONAL_TEST_EMAIL "valid email address"
 EMAIL_TEMPLATE_ID "valid email_template_id"
 SMS_TEMPLATE_ID "valid sms_template_id"
 LETTER_TEMPLATE_ID "valid letter_template_id"
+SMS_SENDER_ID "valid sms_sender_id - to test sending to a receiving number, so needs to be a real number"
+API_SENDING_KEY "API_whitelist_key for sending an SMS to a receiving number"
+INBOUND_SMS_QUERY_KEY "API_test_key to get received text messages"
 ```

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,14 @@ single-test: ## Run a single test: make single-test test=[fully qualified test w
 build-test: dependencies ## build and test
 	make test
 
+.PHONY: build-integration-test
+build-integration-test: dependencies ## build and test
+	make integration-test
+
 .PHONY: build-test_all
 build-test_all: dependencies ## build and test all
 	make test
+	make authentication-test
 	make integration-test
 
 .PHONY: build-release

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ build-test_all: dependencies ## build and test all
 .PHONY: build-release
 build-release: dependencies ## build release version
 	msbuild src/Notify/Notify.csproj /property:Configuration=Release
-\
+
 .PHONY: build-package
 build-package: build-release ## build nuget package
 	nuget pack src/Notify/Notify.csproj -Properties Configuration=Release

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ build: dependencies ## Build project
 test: ## Run unit tests
 	nunit-console NotifyTests/bin/Debug/NotifyTests.dll -include=Unit/NotificationClient -labels
 
+.PHONY: integration-test
+integration-test: ## Run integration tests
+	nunit-console NotifyTests/bin/Debug/NotifyTests.dll -include=Integration -labels
+
 .PHONY: build-test
 build-test: dependencies ## build and test
 	make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+DATE = $(shell date +%Y-%m-%d:%H:%M:%S)
+
+APP_VERSION_FILE = src/Notify/Properties/AssemblyInfo.cs
+
+.PHONY: help
+help:
+	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: dependencies
+dependencies: ## Install build dependencies
+	nuget restore
+	msbuild
+
+.PHONY: build
+build: dependencies ## Build project
+
+.PHONY: test
+test: ## Run unit tests
+	nunit-console NotifyTests/bin/Debug/NotifyTests.dll -include=Unit/NotificationClient -labels
+
+.PHONY: build-test
+build-test: dependencies ## build and test
+	make test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
 .DEFAULT_GOAL := help
-SHELL := /bin/bash
-DATE = $(shell date +%Y-%m-%d:%H:%M:%S)
-
-APP_VERSION_FILE = src/Notify/Properties/AssemblyInfo.cs
 
 .PHONY: help
 help:
@@ -11,19 +7,40 @@ help:
 .PHONY: dependencies
 dependencies: ## Install build dependencies
 	nuget restore
-	msbuild
 
 .PHONY: build
 build: dependencies ## Build project
+	msbuild
 
 .PHONY: test
 test: ## Run unit tests
 	nunit-console NotifyTests/bin/Debug/NotifyTests.dll -include=Unit/NotificationClient -labels
 
+.PHONY: authentication-test
+authentication-test: ## Run integration tests
+	nunit-console NotifyTests/bin/Debug/NotifyTests.dll -include=Unit/AuthenticationTests -labels
+
 .PHONY: integration-test
 integration-test: ## Run integration tests
 	nunit-console NotifyTests/bin/Debug/NotifyTests.dll -include=Integration -labels
 
+.PHONY: single-test
+single-test: ## Run a single test: make single-test test=[fully qualified test with namespace]
+	nunit-console NotifyTests/bin/Debug/NotifyTests.dll -nologo -nodots -run=$(test)
+
 .PHONY: build-test
 build-test: dependencies ## build and test
 	make test
+
+.PHONY: build-test_all
+build-test_all: dependencies ## build and test all
+	make test
+	make integration-test
+
+.PHONY: build-release
+build-release: dependencies ## build release version
+	msbuild src/Notify/Notify.csproj /property:Configuration=Release
+\
+.PHONY: build-package
+build-package: build-release ## build nuget package
+	nuget pack src/Notify/Notify.csproj -Properties Configuration=Release

--- a/NotifyTests/IntegrationTests/Assertions.cs
+++ b/NotifyTests/IntegrationTests/Assertions.cs
@@ -1,0 +1,88 @@
+using Notify.Client;
+using Notify.Models;
+using Notify.Models.Responses;
+using Notify.Exceptions;
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+namespace Notify.IntegrationTests.Assertions
+{
+	public class NotifyAssertions
+	{
+		static public void AssertNotification(Notification notification)
+		{
+			Assert.IsNotNull(notification.type);
+			String notificationType = notification.type;
+			String[] allowedNotificationTypes = { "email", "sms", "letter" };
+			CollectionAssert.Contains(allowedNotificationTypes, notificationType);
+			if (notificationType.Equals("sms"))
+			{
+				Assert.IsNotNull(notification.phoneNumber);
+			}
+			else if (notificationType.Equals("email"))
+			{
+				Assert.IsNotNull(notification.emailAddress);
+				Assert.IsNotNull(notification.subject);
+			}
+			else if (notificationType.Equals("letter"))
+			{
+				Assert.IsNotNull(notification.subject);
+			}
+
+			Assert.IsNotNull(notification.body);
+			Assert.IsNotNull(notification.createdAt);
+
+			Assert.IsNotNull(notification.status);
+			String notificationStatus = notification.status;
+			String[] allowedStatusTypes = {
+				"created",
+				"sending",
+				"delivered",
+				"permanent-failure",
+				"temporary-failure",
+				"technical-failure",
+				"accepted"
+			};
+			CollectionAssert.Contains(allowedStatusTypes, notificationStatus);
+
+			if (notificationStatus.Equals("delivered"))
+			{
+				Assert.IsNotNull(notification.completedAt);
+			}
+
+			AssertTemplate(notification.template);
+		}
+
+		static public void AssertReceivedTextResponse(ReceivedTextResponse receivedTextResponse)
+		{
+			Assert.IsNotNull(receivedTextResponse);
+			Assert.IsNotNull(receivedTextResponse.id);
+			Assert.IsNotNull(receivedTextResponse.content);
+			// Assert.IsNotNull(template.version);
+		}
+
+		static public void AssertTemplate(Template template)
+		{
+			Assert.IsNotNull(template);
+			Assert.IsNotNull(template.id);
+			Assert.IsNotNull(template.uri);
+			Assert.IsNotNull(template.version);
+		}
+
+		static public void AssertTemplateResponse(TemplateResponse template, String type = null)
+		{
+			Assert.IsNotNull(template);
+			Assert.IsNotNull(template.id);
+			Assert.IsNotNull(template.name);
+			Assert.IsNotNull(template.version);
+			Assert.IsNotNull(template.type);
+			if (template.type.Equals("email") || (!string.IsNullOrEmpty(type) && type.Equals("email")))
+				Assert.IsNotNull(template.subject);
+			Assert.IsNotNull(template.created_at);
+			Assert.IsNotNull(template.created_by);
+			Assert.IsNotNull(template.body);
+		}
+    }
+}

--- a/NotifyTests/IntegrationTests/Assertions.cs
+++ b/NotifyTests/IntegrationTests/Assertions.cs
@@ -60,7 +60,6 @@ namespace Notify.IntegrationTests.Assertions
 			Assert.IsNotNull(receivedTextResponse);
 			Assert.IsNotNull(receivedTextResponse.id);
 			Assert.IsNotNull(receivedTextResponse.content);
-			// Assert.IsNotNull(template.version);
 		}
 
 		static public void AssertTemplate(Template template)

--- a/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
+++ b/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
@@ -14,8 +14,6 @@ namespace Notify.IntegrationTests
 	public class NotificationIntegrationClientTests
 	{
 		private NotificationClient client;
-		private NotificationClient client_sending;
-		private NotificationClient client_inbound;
 
 		private String NOTIFY_API_URL = Environment.GetEnvironmentVariable("NOTIFY_API_URL");
 		private String API_KEY = Environment.GetEnvironmentVariable("API_KEY");
@@ -50,8 +48,6 @@ namespace Notify.IntegrationTests
 		public void SetUp()
 		{
 			this.client = new NotificationClient(NOTIFY_API_URL, API_KEY);
-			this.client_sending = new NotificationClient(NOTIFY_API_URL, API_SENDING_KEY);
-			this.client_inbound = new NotificationClient(NOTIFY_API_URL, INBOUND_SMS_QUERY_KEY);
 		}
 
 		[Test, Category("Integration")]
@@ -185,7 +181,8 @@ namespace Notify.IntegrationTests
 		[Test, Category("Integration")]
 		public void GetReceivedTexts()
 		{
-			ReceivedTextListResponse receivedTextListResponse = this.client_inbound.GetReceivedTexts();
+			NotificationClient client_inbound = new NotificationClient(NOTIFY_API_URL, INBOUND_SMS_QUERY_KEY);
+			ReceivedTextListResponse receivedTextListResponse = client_inbound.GetReceivedTexts();
 			Assert.IsNotNull(receivedTextListResponse);
 			Assert.IsNotNull(receivedTextListResponse.receivedTexts);
 			Assert.IsTrue(receivedTextListResponse.receivedTexts.Count > 0);
@@ -395,7 +392,7 @@ namespace Notify.IntegrationTests
 			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
 		}
 
-				[Test, Category("Integration")]
+		[Test, Category("Integration")]
 		public void SendSmsTestWithPersonalisationAndSmsSenderId()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -403,8 +400,10 @@ namespace Notify.IntegrationTests
 				{ "name", "someone" }
 			};
 
+			NotificationClient client_sending = new NotificationClient(NOTIFY_API_URL, API_SENDING_KEY);
+
 			SmsNotificationResponse response =
-				this.client_sending.SendSms(FUNCTIONAL_TEST_NUMBER, SMS_TEMPLATE_ID, personalisation, "sample-test-ref", SMS_SENDER_ID);
+				client_sending.SendSms(FUNCTIONAL_TEST_NUMBER, SMS_TEMPLATE_ID, personalisation, "sample-test-ref", SMS_SENDER_ID);
 			this.smsNotificationId = response.id;
 			Assert.IsNotNull(response);
 			Assert.AreEqual(response.content.body, TEST_SMS_BODY);

--- a/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
+++ b/NotifyTests/IntegrationTests/NotificationIntegrationClientTests.cs
@@ -2,6 +2,7 @@
 using Notify.Models;
 using Notify.Models.Responses;
 using Notify.Exceptions;
+using Notify.IntegrationTests.Assertions;
 using System;
 using System.Collections.Generic;
 
@@ -13,9 +14,13 @@ namespace Notify.IntegrationTests
 	public class NotificationIntegrationClientTests
 	{
 		private NotificationClient client;
+		private NotificationClient client_sending;
+		private NotificationClient client_inbound;
 
 		private String NOTIFY_API_URL = Environment.GetEnvironmentVariable("NOTIFY_API_URL");
 		private String API_KEY = Environment.GetEnvironmentVariable("API_KEY");
+		private String API_SENDING_KEY = Environment.GetEnvironmentVariable("API_SENDING_KEY");
+
 		private String FUNCTIONAL_TEST_NUMBER = Environment.GetEnvironmentVariable("FUNCTIONAL_TEST_NUMBER");
 		private String FUNCTIONAL_TEST_EMAIL = Environment.GetEnvironmentVariable("FUNCTIONAL_TEST_EMAIL");
 
@@ -23,6 +28,8 @@ namespace Notify.IntegrationTests
 		private String SMS_TEMPLATE_ID = Environment.GetEnvironmentVariable("SMS_TEMPLATE_ID");
 		private String LETTER_TEMPLATE_ID = Environment.GetEnvironmentVariable("LETTER_TEMPLATE_ID");
 		private String EMAIL_REPLY_TO_ID = Environment.GetEnvironmentVariable("EMAIL_REPLY_TO_ID");
+		private String SMS_SENDER_ID = Environment.GetEnvironmentVariable("SMS_SENDER_ID");
+		private String INBOUND_SMS_QUERY_KEY = Environment.GetEnvironmentVariable("INBOUND_SMS_QUERY_KEY");
 
 		private String smsNotificationId;
 		private String emailNotificationId;
@@ -43,6 +50,8 @@ namespace Notify.IntegrationTests
 		public void SetUp()
 		{
 			this.client = new NotificationClient(NOTIFY_API_URL, API_KEY);
+			this.client_sending = new NotificationClient(NOTIFY_API_URL, API_SENDING_KEY);
+			this.client_inbound = new NotificationClient(NOTIFY_API_URL, INBOUND_SMS_QUERY_KEY);
 		}
 
 		[Test, Category("Integration")]
@@ -79,7 +88,7 @@ namespace Notify.IntegrationTests
 			Assert.IsNotNull(notification.reference);
 			Assert.AreEqual(notification.reference, "sample-test-ref");
 
-			AssertNotification(notification);
+			NotifyAssertions.AssertNotification(notification);
 		}
 
 		[Test, Category("Integration")]
@@ -104,7 +113,6 @@ namespace Notify.IntegrationTests
 		{
 			SendEmailTestWithPersonalisation();
 			Notification notification = this.client.GetNotificationById(this.emailNotificationId);
-
 			Assert.IsNotNull(notification);
 			Assert.IsNotNull(notification.id);
 			Assert.AreEqual(notification.id, this.emailNotificationId);
@@ -114,7 +122,7 @@ namespace Notify.IntegrationTests
 			Assert.IsNotNull(notification.subject);
 			Assert.AreEqual(notification.subject, TEST_EMAIL_SUBJECT);
 
-			AssertNotification(notification);
+			NotifyAssertions.AssertNotification(notification);
 		}
 
 		[Test, Category("Integration")]
@@ -155,9 +163,8 @@ namespace Notify.IntegrationTests
 			Assert.IsNotNull(notification.subject);
 			Assert.AreEqual(notification.subject, TEST_LETTER_SUBJECT);
 
-			AssertNotification(notification);
+			NotifyAssertions.AssertNotification(notification);
 		}
-
 
 		[Test, Category("Integration")]
 		public void GetAllNotifications()
@@ -170,9 +177,25 @@ namespace Notify.IntegrationTests
 
 			foreach (Notification notification in notifications)
 			{
-				AssertNotification(notification);
+				NotifyAssertions.AssertNotification(notification);
 			}
 
+		}
+
+		[Test, Category("Integration")]
+		public void GetReceivedTexts()
+		{
+			ReceivedTextListResponse receivedTextListResponse = this.client_inbound.GetReceivedTexts();
+			Assert.IsNotNull(receivedTextListResponse);
+			Assert.IsNotNull(receivedTextListResponse.receivedTexts);
+			Assert.IsTrue(receivedTextListResponse.receivedTexts.Count > 0);
+
+			List<ReceivedTextResponse> receivedTexts = receivedTextListResponse.receivedTexts;
+
+			foreach (ReceivedTextResponse receivedText in receivedTexts)
+			{
+				NotifyAssertions.AssertReceivedTextResponse(receivedText);
+			}
 		}
 
 		[Test, Category("Integration")]
@@ -211,7 +234,7 @@ namespace Notify.IntegrationTests
 
 			foreach (TemplateResponse template in templateList.templates)
 			{
-				AssertTemplateResponse(template);
+				NotifyAssertions.AssertTemplateResponse(template);
 			}
 		}
 
@@ -225,7 +248,7 @@ namespace Notify.IntegrationTests
 
 			foreach (TemplateResponse template in templateList.templates)
 			{
-				AssertTemplateResponse(template, type);
+				NotifyAssertions.AssertTemplateResponse(template, type);
 			}
 		}
 
@@ -239,7 +262,7 @@ namespace Notify.IntegrationTests
 
 			foreach (TemplateResponse template in templateList.templates)
 			{
-				AssertTemplateResponse(template, type);
+				NotifyAssertions.AssertTemplateResponse(template, type);
 			}
 		}
 
@@ -314,72 +337,6 @@ namespace Notify.IntegrationTests
 			Assert.That(ex.Message, Does.Contain("Missing personalisation: name"));
 		}
 
-		public void AssertNotification(Notification notification)
-		{
-			Assert.IsNotNull(notification.type);
-			String notificationType = notification.type;
-			String[] allowedNotificationTypes = { "email", "sms", "letter" };
-			CollectionAssert.Contains(allowedNotificationTypes, notificationType);
-			if (notificationType.Equals("sms"))
-			{
-				Assert.IsNotNull(notification.phoneNumber);
-			}
-			else if (notificationType.Equals("email"))
-			{
-				Assert.IsNotNull(notification.emailAddress);
-				Assert.IsNotNull(notification.subject);
-			}
-			else if (notificationType.Equals("letter"))
-			{
-				Assert.IsNotNull(notification.subject);
-			}
-
-			Assert.IsNotNull(notification.body);
-			Assert.IsNotNull(notification.createdAt);
-
-			Assert.IsNotNull(notification.status);
-			String notificationStatus = notification.status;
-			String[] allowedStatusTypes = {
-				"created",
-				"sending",
-				"delivered",
-				"permanent-failure",
-				"temporary-failure",
-				"technical-failure",
-				"accepted"
-			};
-			CollectionAssert.Contains(allowedStatusTypes, notificationStatus);
-
-			if (notificationStatus.Equals("delivered"))
-			{
-				Assert.IsNotNull(notification.completedAt);
-			}
-
-			AssertTemplate(notification.template);
-		}
-
-		public void AssertTemplate(Template template)
-		{
-			Assert.IsNotNull(template);
-			Assert.IsNotNull(template.id);
-			Assert.IsNotNull(template.uri);
-			Assert.IsNotNull(template.version);
-		}
-
-		public void AssertTemplateResponse(TemplateResponse template, String type = null)
-		{
-			Assert.IsNotNull(template);
-			Assert.IsNotNull(template.id);
-			Assert.IsNotNull(template.name);
-			Assert.IsNotNull(template.version);
-			Assert.IsNotNull(template.type);
-			if (template.type.Equals("email") || (!string.IsNullOrEmpty(type) && type.Equals("email")))
-				Assert.IsNotNull(template.subject);
-			Assert.IsNotNull(template.created_at);
-			Assert.IsNotNull(template.created_by);
-			Assert.IsNotNull(template.body);
-		}
-		
 		[Test, Category("Integration")]
 		public void SendEmailTestServiceDefaultEmailReplyTo()
 		{
@@ -437,5 +394,25 @@ namespace Notify.IntegrationTests
 			Assert.AreEqual(response.content.body, TEST_EMAIL_BODY);
 			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
 		}
+
+				[Test, Category("Integration")]
+		public void SendSmsTestWithPersonalisationAndSmsSenderId()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			SmsNotificationResponse response =
+				this.client_sending.SendSms(FUNCTIONAL_TEST_NUMBER, SMS_TEMPLATE_ID, personalisation, "sample-test-ref", SMS_SENDER_ID);
+			this.smsNotificationId = response.id;
+			Assert.IsNotNull(response);
+			Assert.AreEqual(response.content.body, TEST_SMS_BODY);
+
+			Assert.IsNotNull(response.reference);
+			Assert.AreEqual(response.reference, "sample-test-ref");
+		}
+
+
 	}
 }

--- a/NotifyTests/NotifyTests.csproj
+++ b/NotifyTests/NotifyTests.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IntegrationTests\NotificationIntegrationClientTests.cs" />
+    <Compile Include="IntegrationTests\Assertions.cs" />
     <Compile Include="UnitTests\NotificationUnitClientTests.cs" />
     <Compile Include="UnitTests\AuthenticatorTests.cs" />
     <Compile Include="UnitTests\Constants.cs" />

--- a/NotifyTests/UnitTests/Constants.cs
+++ b/NotifyTests/UnitTests/Constants.cs
@@ -170,13 +170,13 @@ namespace Notify.UnitTests
             }
         }
 
-        public static String fakeSmsNotificationWIthSMSSenderIdResponseJson { get {
+        public static String fakeSmsNotificationWithSMSSenderIdResponseJson { get {
                 return @"{
                             ""content"": {
                                 ""body"": ""test"",
                                 ""from_number"": ""GOV.UK"" },
                             ""id"": ""d683f7f9-df04-4b9c-8019-15092c4674fd"",
-                            ""reference"":  ""some-client-ref"",
+                            ""reference"":  null,
                             ""template"": {
                                 ""id"": ""be35a391-e912-42e9-82e6-3f4953f6cbb0"",
                                 ""uri"": ""http://someurl/v2/templates/be35a391-e912-42e9-82e6-3f4953f6cbb0"",

--- a/NotifyTests/UnitTests/Constants.cs
+++ b/NotifyTests/UnitTests/Constants.cs
@@ -83,6 +83,33 @@ namespace Notify.UnitTests
             }
         }
 
+        public static String fakeReceivedTextListResponseJson { get {
+                return @"{ ""received_text_messages"": [
+                        { 
+                            ""provider_date"": ""2017-11-02T15:07:57.199541Z"",
+                            ""provider_reference"": ""foo"",
+                            ""user_number"": ""447700900111"",
+                            ""created_at"": ""2017-11-02T15:07:57.197546Z"",
+                            ""service_id"": ""a5149c32-f03b-4711-af49-ad6993797d45"",
+                            ""id"": ""342786aa-23ce-4695-9aad-7f79e68ee29a"",
+                            ""notify_number"": ""testing"",
+                            ""content"": ""Hello""
+                        },
+                        { 
+                            ""provider_date"": ""2017-11-02T15:07:57.199541Z"",
+                            ""provider_reference"": ""foo"",
+                            ""user_number"": ""447700900111"",
+                            ""created_at"": ""2017-11-02T15:07:57.197546Z"",
+                            ""service_id"": ""a5149c32-f03b-4711-af49-ad6993797d45"",
+                            ""id"": ""342786aa-23ce-4695-9aad-7f79e68ee29a"",
+                            ""notify_number"": ""testing"",
+                            ""content"": ""Hello again""
+                        }
+					]
+				}";
+            }
+        }
+
         public static String fakeTemplateEmptyListResponseJson
         {
         	get

--- a/NotifyTests/UnitTests/Constants.cs
+++ b/NotifyTests/UnitTests/Constants.cs
@@ -16,6 +16,7 @@ namespace Notify.UnitTests
         public static String fakeNotificationReference { get { return "some-client-ref"; } }
         public static String fakeTemplateId { get { return "913e9fa6-9cbb-44ad-8f58-38487dccfd82"; } }
         public static String fakeReplyToId { get { return "78ded4ad-e915-4a89-a314-2940ed141d40"; } }
+        public static String fakeSMSSenderId { get { return "88ded4ad-e915-4a89-a314-2940ed141d41"; } }
         public static String fakeNotificationJson { get {
                 return @"{
                             ""completed_at"": null,
@@ -86,8 +87,6 @@ namespace Notify.UnitTests
         public static String fakeReceivedTextListResponseJson { get {
                 return @"{ ""received_text_messages"": [
                         { 
-                            ""provider_date"": ""2017-11-02T15:07:57.199541Z"",
-                            ""provider_reference"": ""foo"",
                             ""user_number"": ""447700900111"",
                             ""created_at"": ""2017-11-02T15:07:57.197546Z"",
                             ""service_id"": ""a5149c32-f03b-4711-af49-ad6993797d45"",
@@ -96,8 +95,6 @@ namespace Notify.UnitTests
                             ""content"": ""Hello""
                         },
                         { 
-                            ""provider_date"": ""2017-11-02T15:07:57.199541Z"",
-                            ""provider_reference"": ""foo"",
                             ""user_number"": ""447700900111"",
                             ""created_at"": ""2017-11-02T15:07:57.197546Z"",
                             ""service_id"": ""a5149c32-f03b-4711-af49-ad6993797d45"",
@@ -164,6 +161,22 @@ namespace Notify.UnitTests
                                 ""from_number"": null },
                             ""id"": ""d683f7f9-df04-4b9c-8019-15092c4674fd"",
                             ""reference"": null,
+                            ""template"": {
+                                ""id"": ""be35a391-e912-42e9-82e6-3f4953f6cbb0"",
+                                ""uri"": ""http://someurl/v2/templates/be35a391-e912-42e9-82e6-3f4953f6cbb0"",
+                                ""version"": 1 },
+                            ""uri"": ""http://some_url//v2/notifications/d683f7f9-df04-4b9c-8019-15092c4674fd""
+                         }";
+            }
+        }
+
+        public static String fakeSmsNotificationWIthSMSSenderIdResponseJson { get {
+                return @"{
+                            ""content"": {
+                                ""body"": ""test"",
+                                ""from_number"": ""GOV.UK"" },
+                            ""id"": ""d683f7f9-df04-4b9c-8019-15092c4674fd"",
+                            ""reference"":  ""some-client-ref"",
                             ""template"": {
                                 ""id"": ""be35a391-e912-42e9-82e6-3f4953f6cbb0"",
                                 ""uri"": ""http://someurl/v2/templates/be35a391-e912-42e9-82e6-3f4953f6cbb0"",

--- a/NotifyTests/UnitTests/NotificationUnitClientTests.cs
+++ b/NotifyTests/UnitTests/NotificationUnitClientTests.cs
@@ -266,6 +266,40 @@ namespace Notify.UnitTests
         }
 
         [Test, Category("Unit/NotificationClient")]
+        public void GetAllReceivedTextsCreatesExpectedRequest()
+        {
+            mockRequest(Constants.fakeReceivedTextListResponseJson,
+                 client.GET_RECEIVED_TEXTS_URL, AssertValidRequest);
+
+            client.GetReceivedTexts();
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllReceivedTextsReceivesExpectedResponse()
+        {
+            mockRequest(Constants.fakeReceivedTextListResponseJson,
+                 client.GET_RECEIVED_TEXTS_URL, AssertValidRequest);
+
+            ReceivedTextListResponse expectedResponse =
+                JsonConvert.DeserializeObject<ReceivedTextListResponse>(Constants.fakeReceivedTextListResponseJson);
+
+            mockRequest(Constants.fakeReceivedTextListResponseJson,
+                         client.GET_RECEIVED_TEXTS_URL, AssertValidRequest);
+
+            ReceivedTextListResponse receivedTextList = client.GetReceivedTexts();
+
+            List<ReceivedTextResponse> receivedTexts = receivedTextList.receivedTexts;
+
+            Assert.AreEqual(receivedTexts.Count, expectedResponse.receivedTexts.Count);
+            for (int i = 0; i < receivedTexts.Count; i++)
+            {
+                Assert.IsTrue(expectedResponse.receivedTexts[i].EqualTo(receivedTexts[i]));
+            }
+
+            client.GetReceivedTexts();
+        }
+
+        [Test, Category("Unit/NotificationClient")]
         public void SendSmsNotificationGeneratesExpectedRequest()
         {
             Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>

--- a/NotifyTests/UnitTests/NotificationUnitClientTests.cs
+++ b/NotifyTests/UnitTests/NotificationUnitClientTests.cs
@@ -295,8 +295,6 @@ namespace Notify.UnitTests
             {
                 Assert.IsTrue(expectedResponse.receivedTexts[i].EqualTo(receivedTexts[i]));
             }
-
-            client.GetReceivedTexts();
         }
 
         [Test, Category("Unit/NotificationClient")]

--- a/NotifyTests/UnitTests/NotificationUnitClientTests.cs
+++ b/NotifyTests/UnitTests/NotificationUnitClientTests.cs
@@ -526,5 +526,30 @@ namespace Notify.UnitTests
 
             Assert.IsTrue(expectedResponse.IsEqualTo(actualResponse));
         }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendSmsNotificationWithSmsSenderIdGeneratesExpectedRequest()
+        {
+            Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+                {
+                    { "name", "someone" }
+                };
+            JObject expected = new JObject
+            {
+                { "phone_number", Constants.fakePhoneNumber },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", JObject.FromObject(personalisation) },
+                { "sms_sender_id", Constants.fakeSMSSenderId }
+            };
+
+            mockRequest(Constants.fakeSmsNotificationWithSMSSenderIdResponseJson,
+                client.SEND_SMS_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            SmsNotificationResponse response = client.SendSms(
+                Constants.fakePhoneNumber, Constants.fakeTemplateId, personalisation: personalisation, smsSenderId: Constants.fakeSMSSenderId);
+        }
     }
 }

--- a/NotifyTests/packages.config
+++ b/NotifyTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
   <package id="Moq" version="4.7.10" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
 </packages>

--- a/NotifyTests/packages.config
+++ b/NotifyTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
   <package id="Moq" version="4.7.10" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ SETX FUNCTIONAL_TEST_EMAIL "valid email address"
 SETX EMAIL_TEMPLATE_ID "valid email_template_id"
 SETX SMS_TEMPLATE_ID "valid sms_template_id"
 SETX LETTER_TEMPLATE_ID "valid letter_template_id"
+SETX SMS_SENDER_ID "valid sms_sender_id - to test sending to a receiving number, so needs to be a real number"
+SETX API_SENDING_KEY "API_whitelist_key for sending an SMS to a receiving number"
+SETX INBOUND_SMS_QUERY_KEY "API_test_key to get received text messages"
 ```
 </details>
 
@@ -41,8 +44,11 @@ In order to get the .Net client running in Visual Studio the target `.Net Framew
 open -n /Applications/"Visual Studio.app"
 ```
 
+If you prefer to run commands from a terminal, a `Makefile` is provided to allow building, testing and nuget packaging.
+- Run `make` on the terminal to give you a list of possible commands
+
 <details>
-<summary>Setting Mac OS Environment variables (these must be sourced before opening the Visual Application using the command above)</summary>
+<summary>Setting Mac OS Environment variables (these must be sourced before opening Visual Studio or running `Makefile` commands using the command above)</summary>
 
 ```
 export NOTIFY_API_URL=https://example.notify-api.url
@@ -52,6 +58,9 @@ export FUNCTIONAL_TEST_EMAIL=valid email address
 export EMAIL_TEMPLATE_ID=valid email_template_id
 export SMS_TEMPLATE_ID=valid sms_template_id
 export LETTER_TEMPLATE_ID=valid letter_template_id
+export SMS_SENDER_ID=valid sms_sender_id - to test sending to a receiving number, so needs to be a real number
+export API_SENDING_KEY=API_whitelist_key for sending an SMS to a receiving number
+export INBOUND_SMS_QUERY_KEY=API_test_key to get received text messages
 ```
 </details>
 
@@ -75,7 +84,7 @@ the **API integration** page.
 ### Text message
 
 ```csharp
-SmsNotificationResponse response = client.SendSms(mobileNumber, templateId, personalisation, reference);
+SmsNotificationResponse response = client.SendSms(mobileNumber, templateId, personalisation, reference, smsSenderId);
 ```
 
 <details>
@@ -83,7 +92,7 @@ SmsNotificationResponse response = client.SendSms(mobileNumber, templateId, pers
 Response
 </summary>
 
-If the request is successful, `response` will be a `SmsNotificationResponse `:
+If the request is successful, `response` will be a `SmsNotificationResponse`:
 
 ```csharp
 public String fromNumber;
@@ -107,10 +116,10 @@ Otherwise the client will raise a `Notify.Exceptions.NotifyClientException`:
 <tr>
 <th>
 
-`error["status_code"]`</th>
+`status_code`</th>
 <th>
 
-`error["message"]`</th>
+`error`</th>
 </tr>
 </thead>
 <tbody>
@@ -207,10 +216,10 @@ Otherwise the client will raise a `Notify.Exceptions.NotifyClientException`:
 <tr>
 <th>
 
-`error["status_code"]`</th>
+`status_code`</th>
 <th>
 
-`error["message"]`</th>
+`error`</th>
 </tr>
 </thead>
 <tbody>
@@ -346,10 +355,10 @@ Otherwise the client will raise a `Notify.Exceptions.NotifyClientException`:
 <tr>
 <th>
 
-`error["status_code"]`</th>
+`status_code`</th>
 <th>
 
-`error["message"]`</th>
+`error`</th>
 </tr>
 </thead>
 <tbody>
@@ -485,8 +494,8 @@ Otherwise the client will raise a `Notify.Exceptions.NotifyClientException`:
 <table>
 <thead>
 <tr>
-<th>`error["status_code"]`</th>
-<th>`error["message"]`</th>
+<th>`status_code`</th>
+<th>`message`</th>
 </tr>
 </thead>
 <tbody>
@@ -676,10 +685,10 @@ Otherwise the client will raise a `Notify.Exceptions.NotifyClientException`:
 <tr>
 <th>
 
-`error["status_code"]`</th>
+`status_code`</th>
 <th>
 
-`error["message"]`</th>
+`error`</th>
 </tr>
 </thead>
 <tbody>
@@ -842,11 +851,11 @@ Otherwise the client will raise a `Notify.Exceptions.NotifyClientException`:
 <tr>
 <th>
 
-`error["status_code"]`
+`status_code`
 </th>
 <th>
 
-`error["message"]`
+`error`
 </th>
 </tr>
 </thead>
@@ -897,4 +906,42 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 {
     { "name", "someone" }
 };
+```
+
+## Send messages
+
+### Text message
+
+```csharp
+ReceivedTextListResponse response = client.GetReceivedTexts();
+```
+
+<details>
+<summary>
+Response
+</summary>
+
+If the request is successful, `response` will be a `ReceivedTextListResponse`:
+
+```csharp
+public List<ReceivedText> receivedTextList;
+public Link links;
+
+public class Link {
+	public String current;
+	public String next;
+}
+
+```
+
+A `ReceivedText` will have the following properties -
+
+```csharp
+public String id;
+public String userNumber;
+public String createdAt;
+public String serviceId;
+public String notifyNumber;
+public String content;
+
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The notifications-net-client is deployed to [Bintray](https://bintray.com/gov-uk
 nuget install Notify -Source https://api.bintray.com/nuget/gov-uk-notify/notifications-net-client
 ```
 
-Alternatively if you are using the Nuget Package Manager in Visual Studio, add the source below to install.
+Alternatively if you are using the NuGet Package Manager in Visual Studio, add the source below to install.
 ```
 https://api.bintray.com/nuget/gov-uk-notify/nuget
 ```
@@ -44,7 +44,7 @@ In order to get the .Net client running in Visual Studio the target `.Net Framew
 open -n /Applications/"Visual Studio.app"
 ```
 
-If you prefer to run commands from a terminal, a `Makefile` is provided to allow building, testing and nuget packaging.
+If you prefer to run commands from a terminal, a `Makefile` is provided to allow building, testing and NuGet packaging.
 - Run `make` on the terminal to give you a list of possible commands
 
 <details>

--- a/src/Notify/Authentication/Authenticator.cs
+++ b/src/Notify/Authentication/Authenticator.cs
@@ -1,6 +1,8 @@
-﻿using Notify.Exceptions;
-using System;
+﻿using System;
 using System.Collections.Generic;
+
+using JWT;
+using Notify.Exceptions;
 
 namespace Notify.Authentication
 {

--- a/src/Notify/Authentication/Authenticator.cs
+++ b/src/Notify/Authentication/Authenticator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 
-using JWT;
 using Notify.Exceptions;
 
 namespace Notify.Authentication

--- a/src/Notify/Client/BaseClient.cs
+++ b/src/Notify/Client/BaseClient.cs
@@ -34,7 +34,6 @@ namespace Notify.Client
 
             String productVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             this.client.AddUserAgent(NOTIFY_CLIENT_NAME + productVersion);
-
         }
 
         public String GET(String url)

--- a/src/Notify/Client/NotificationClient.cs
+++ b/src/Notify/Client/NotificationClient.cs
@@ -14,7 +14,7 @@ namespace Notify.Client
     public class NotificationClient : BaseClient
     {
         public String GET_RECEIVED_TEXTS_URL = "v2/received-text-messages";
-        public String GET_NOTIFICATION_URL = "v2/notifications";
+        public String GET_NOTIFICATION_URL = "v2/notifications/";
         public String SEND_SMS_NOTIFICATION_URL = "v2/notifications/sms";
         public String SEND_EMAIL_NOTIFICATION_URL = "v2/notifications/email";
         public String SEND_LETTER_NOTIFICATION_URL = "v2/notifications/letter";
@@ -117,10 +117,15 @@ namespace Notify.Client
             return receivedTexts;
         }
 
-        public SmsNotificationResponse SendSms(String mobileNumber, String templateId, Dictionary<String, dynamic> personalisation = null, String clientReference = null)
+        public SmsNotificationResponse SendSms(String mobileNumber, String templateId, Dictionary<String, dynamic> personalisation = null, String clientReference = null, String smsSenderId = null)
         {
             JObject o = CreateRequestParams(templateId, personalisation, clientReference);
             o.AddFirst(new JProperty("phone_number", mobileNumber));
+
+            if (smsSenderId != null)
+            {
+                o.Add(new JProperty("sms_sender_id", smsSenderId));
+            }
 
             String response = this.POST(SEND_SMS_NOTIFICATION_URL, o.ToString(Formatting.None));
 

--- a/src/Notify/Client/NotificationClient.cs
+++ b/src/Notify/Client/NotificationClient.cs
@@ -13,7 +13,8 @@ namespace Notify.Client
 {
     public class NotificationClient : BaseClient
     {
-        public String GET_NOTIFICATION_URL = "v2/notifications/";
+        public String GET_RECEIVED_TEXTS_URL = "v2/received-text-messages";
+        public String GET_NOTIFICATION_URL = "v2/notifications";
         public String SEND_SMS_NOTIFICATION_URL = "v2/notifications/sms";
         public String SEND_EMAIL_NOTIFICATION_URL = "v2/notifications/email";
         public String SEND_LETTER_NOTIFICATION_URL = "v2/notifications/letter";
@@ -100,6 +101,20 @@ namespace Notify.Client
             TemplateList templateList = JsonConvert.DeserializeObject<TemplateList>(response);
 
             return templateList;
+        }
+
+        public ReceivedTextListResponse GetReceivedTexts(String olderThanId = "")
+        {
+            String finalUrl = String.Format(
+                "{0}{1}",
+                GET_RECEIVED_TEXTS_URL,
+                String.IsNullOrWhiteSpace(olderThanId) ? "" : "?older_than=" + olderThanId
+            );
+
+            String response = this.GET(finalUrl);
+
+            ReceivedTextListResponse receivedTexts = JsonConvert.DeserializeObject<ReceivedTextListResponse>(response);
+            return receivedTexts;
         }
 
         public SmsNotificationResponse SendSms(String mobileNumber, String templateId, Dictionary<String, dynamic> personalisation = null, String clientReference = null)

--- a/src/Notify/Models/Link.cs
+++ b/src/Notify/Models/Link.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Notify.Models
+{
+    public class Link
+    {
+        [JsonProperty("current")]
+        public String current;
+        [JsonProperty("next")]
+        public String next;
+    }
+}

--- a/src/Notify/Models/NotificationList.cs
+++ b/src/Notify/Models/NotificationList.cs
@@ -11,12 +11,4 @@ namespace Notify.Models
         [JsonProperty("links")]
         public Link links;
     }
-
-    public class Link
-    {
-        [JsonProperty("current")]
-        public String current;
-        [JsonProperty("next")]
-        public String next;
-    }
 }

--- a/src/Notify/Models/NotificationList.cs
+++ b/src/Notify/Models/NotificationList.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using Notify.Models.Responses;
 
 namespace Notify.Models
 {

--- a/src/Notify/Models/Responses/Link.cs
+++ b/src/Notify/Models/Responses/Link.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
-namespace Notify.Models
+namespace Notify.Models.Responses
 {
     public class Link
     {

--- a/src/Notify/Models/Responses/ReceivedTextListResponse.cs
+++ b/src/Notify/Models/Responses/ReceivedTextListResponse.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Notify.Models.Responses
+{
+    public class ReceivedTextListResponse
+    {
+        [JsonProperty("received_text_messages")]
+        public List<ReceivedTextResponse> receivedTexts;
+        [JsonProperty("links")]
+        public Link links;
+    }
+}

--- a/src/Notify/Models/Responses/ReceivedTextResponse.cs
+++ b/src/Notify/Models/Responses/ReceivedTextResponse.cs
@@ -8,14 +8,10 @@ namespace Notify.Models.Responses
         public String id;
         [JsonProperty("created_at")]
         public String createdAt;
-        [JsonProperty("provider_date")]
-        public String providerDate;
         [JsonProperty("notify_number")]
         public String notifyNumber;
         [JsonProperty("user_number")]
         public String userNumber;
-        [JsonProperty("provider_reference")]
-        public String providerReference;
         [JsonProperty("service_id")]
         public String serviceId;
         public String content;
@@ -25,10 +21,8 @@ namespace Notify.Models.Responses
             return (
                 id == receivedText.id &&
                 createdAt == receivedText.createdAt &&
-                providerDate == receivedText.providerDate &&
                 notifyNumber == receivedText.notifyNumber &&
                 userNumber == receivedText.userNumber &&
-                providerReference == receivedText.providerReference &&
                 serviceId == receivedText.serviceId &&
                 content == receivedText.content
             );

--- a/src/Notify/Models/Responses/ReceivedTextResponse.cs
+++ b/src/Notify/Models/Responses/ReceivedTextResponse.cs
@@ -1,0 +1,37 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Notify.Models.Responses
+{
+    public class ReceivedTextResponse
+    {
+        public String id;
+        [JsonProperty("created_at")]
+        public String createdAt;
+        [JsonProperty("provider_date")]
+        public String providerDate;
+        [JsonProperty("notify_number")]
+        public String notifyNumber;
+        [JsonProperty("user_number")]
+        public String userNumber;
+        [JsonProperty("provider_reference")]
+        public String providerReference;
+        [JsonProperty("service_id")]
+        public String serviceId;
+        public String content;
+
+        public bool EqualTo(ReceivedTextResponse receivedText)
+        {
+            return (
+                id == receivedText.id &&
+                createdAt == receivedText.createdAt &&
+                providerDate == receivedText.providerDate &&
+                notifyNumber == receivedText.notifyNumber &&
+                userNumber == receivedText.userNumber &&
+                providerReference == receivedText.providerReference &&
+                serviceId == receivedText.serviceId &&
+                content == receivedText.content
+            );
+        }
+    }
+}

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -43,10 +43,10 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="JWT">
-      <HintPath>..\..\packages\JWT.2.4.1\lib\net35\JWT.dll</HintPath>
+      <HintPath>..\..\packages\JWT.2.4.2\lib\net35\JWT.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -53,26 +53,29 @@
     <Compile Include="Authentication\Authenticator.cs" />
     <Compile Include="Client\BaseClient.cs" />
     <Compile Include="Client\HttpClientWrapper.cs" />
+    <Compile Include="Client\NotificationClient.cs" />
     <Compile Include="Exceptions\NotifyAuthException.cs" />
     <Compile Include="Exceptions\NotifyClientException.cs" />
     <Compile Include="Interfaces\IBaseClient.cs" />
     <Compile Include="Interfaces\IHttpClient.cs" />
     <Compile Include="Interfaces\INotificationClient.cs" />
+    <Compile Include="Models\Responses\Link.cs" />
     <Compile Include="Models\NotificationList.cs" />
+    <Compile Include="Models\Notification.cs" />
+    <Compile Include="Models\NotifyHTTPError.cs" />
     <Compile Include="Models\Responses\EmailNotificationResponse.cs" />
     <Compile Include="Models\Responses\TemplateList.cs" />
     <Compile Include="Models\Responses\NotificationResponse.cs" />
-    <Compile Include="Models\NotifyHTTPError.cs" />
     <Compile Include="Models\Responses\NotifyHTTPErrorResponse.cs" />
-    <Compile Include="Models\Notification.cs" />
     <Compile Include="Models\Responses\SmsNotificationResponse.cs" />
     <Compile Include="Models\Responses\TemplatePreviewResponse.cs" />
     <Compile Include="Models\Responses\TemplateResponse.cs" />
+    <Compile Include="Models\Responses\LetterNotificationResponse.cs" />
+    <Compile Include="Models\Responses\ReceivedTextResponse.cs" />
+    <Compile Include="Models\Responses\ReceivedTextListResponse.cs" />
     <Compile Include="Models\Template.cs" />
-    <Compile Include="Client\NotificationClient.cs" />
     <Compile Include="Models\TemplatePreview.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Models\Responses\LetterNotificationResponse.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -43,7 +43,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="JWT">
       <HintPath>..\..\packages\JWT.2.4.2\lib\net35\JWT.dll</HintPath>

--- a/src/Notify/Properties/AssemblyInfo.cs
+++ b/src/Notify/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.3")]
+[assembly: AssemblyVersion("1.6.0")]

--- a/src/Notify/packages.config
+++ b/src/Notify/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JWT" version="1.3.4" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="JWT" version="2.4.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
 </packages>

--- a/src/Notify/packages.config
+++ b/src/Notify/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JWT" version="2.4.1" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="JWT" version="1.3.4" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
## What 
Added extra functionality in this client to 

- Pin dependencies to versions so that this will work with .Net framework 4.6.2 and 4.7.
- Allow sending of sms from an sms_sender by passing in the optional `sms_sender_id`.
- Extra function to get all received texts `GetReceivedTexts`, response is paged with a size of 250.
- Added a `Makefile` to make it easier for non Visual Studio developers to build, test and package the client.

## Checklist

- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `README.md`)
- [x] I’ve bumped the version number (in `src/Notify/Properties/AssemblyInfo.cs`)
