### PR TITLE
Pin dependencies to prevent problems during upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.3] - 2017-11-15
+## Changed
+
+* Pin dependencies for JWT and Newtonsoft.json
+    * Pinned to no higher than JWT 2.4.2 and Newtonsoft.json 10.
+
 ## [1.5.2] - 2017-10-11
 ## Changed
 

--- a/src/Notify/Notify.nuspec
+++ b/src/Notify/Notify.nuspec
@@ -12,8 +12,8 @@
     <copyright>Copyright 2016</copyright>
     <tags>Notify .NET-Client</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="9.0.1" />
-      <dependency id="JWT" version="1.3.4" />
+      <dependency id="Newtonsoft.Json" version="[9,10.0.4)" />
+      <dependency id="JWT" version="[2.4.2,2.4.3)" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Notify/Properties/AssemblyInfo.cs
+++ b/src/Notify/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.2")]
+[assembly: AssemblyVersion("1.5.3")]


### PR DESCRIPTION
## What

Needed to pin the dependencies as when trying to upgrade the packages to the latest versions the libraries do not work with .Net framework.

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes - not applicable
- [x] I’ve update the documentation (in `README.md, CHANGELOG.md`)
- [x] I’ve bumped the version number (in `src/Notify/Properties/AssemblyInfo.cs`)
