### PR TITLE
Updated lower limit to for JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.1] - 2017-11-16
+## Changed
+
+* Updated `Notify.nuspec, Notify.csproj, packages.config` dependencies for JWT and Newtonsoft.json
+    * Change lower dependency set for JWT set to 1.3.4 and Newtonsoft.json to 9.0.1.
+
 ## [1.6.0] - 2017-11-15
 ## Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ FUNCTIONAL_TEST_EMAIL "valid email address"
 EMAIL_TEMPLATE_ID "valid email_template_id"
 SMS_TEMPLATE_ID "valid sms_template_id"
 LETTER_TEMPLATE_ID "valid letter_template_id"
-SMS_SENDER_ID "valid sms_sender_id - to test sending to a receiving number, so needs to be a real number"
+SMS_SENDER_ID "valid sms_sender_id - to test sending to a receiving number, so needs to be a valid number"
 API_SENDING_KEY "API_whitelist_key for sending an SMS to a receiving number"
 INBOUND_SMS_QUERY_KEY "API_test_key to get received text messages"
 ```

--- a/NotifyTests/NotifyTests.csproj
+++ b/NotifyTests/NotifyTests.csproj
@@ -40,7 +40,7 @@
       <HintPath>..\packages\Moq.4.7.10\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/NotifyTests/packages.config
+++ b/NotifyTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
   <package id="Moq" version="4.7.10" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ SETX FUNCTIONAL_TEST_EMAIL "valid email address"
 SETX EMAIL_TEMPLATE_ID "valid email_template_id"
 SETX SMS_TEMPLATE_ID "valid sms_template_id"
 SETX LETTER_TEMPLATE_ID "valid letter_template_id"
-SETX SMS_SENDER_ID "valid sms_sender_id - to test sending to a receiving number, so needs to be a real number"
+SETX SMS_SENDER_ID "valid sms_sender_id - to test sending to a receiving number, so needs to be a valid number"
 SETX API_SENDING_KEY "API_whitelist_key for sending an SMS to a receiving number"
 SETX INBOUND_SMS_QUERY_KEY "API_test_key to get received text messages"
 ```
@@ -80,6 +80,9 @@ export FUNCTIONAL_TEST_EMAIL=valid email address
 export EMAIL_TEMPLATE_ID=valid email_template_id
 export SMS_TEMPLATE_ID=valid sms_template_id
 export LETTER_TEMPLATE_ID=valid letter_template_id
+export SMS_SENDER_ID=valid sms_sender_id  # to test sending to a receiving number, so needs to be a valid number
+export API_SENDING_KEY=API_whitelist_key  # for sending an SMS to a receiving number
+export INBOUND_SMS_QUERY_KEY=API_test_key  # to get received text messages
 ```
 </details>
 
@@ -181,7 +184,7 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 };
 ```
 
-### `sms_sender_id`
+### `smsSenderId`
 
 Optional. Specifies the identifier of the sms sender to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Text message sender'.
 

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -43,10 +43,10 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="JWT">
-      <HintPath>..\..\packages\JWT.2.4.2\lib\net35\JWT.dll</HintPath>
+      <HintPath>..\..\packages\JWT.1.3.4\lib\3.5\JWT.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Notify/Notify.nuspec
+++ b/src/Notify/Notify.nuspec
@@ -12,8 +12,8 @@
     <copyright>Copyright 2016</copyright>
     <tags>Notify .NET-Client</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="[9,10.0.4)" />
-      <dependency id="JWT" version="[2.4.2,2.4.3)" />
+      <dependency id="Newtonsoft.Json" version="[9.0.1,10.0.4)" />
+      <dependency id="JWT" version="[1.3.4,3.1.1)" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Notify/Properties/AssemblyInfo.cs
+++ b/src/Notify/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0")]
+[assembly: AssemblyVersion("1.6.1")]

--- a/src/Notify/packages.config
+++ b/src/Notify/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JWT" version="2.4.2" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="JWT" version="1.3.4" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- lower limit of JWT 2.4.2 required Json.Net 10, so have downgraded lower limit of JWT to 1.3.4 which uses Json.Net 9

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes - NA
- [ ] I’ve update the documentation (in `README.md`) - NA
- [x] I’ve bumped the version number (in `src/Notify/Properties/AssemblyInfo.cs`)
