### PR TITLE
Use master branch for appveyor config

### DIFF
--- a/appveyor.txt
+++ b/appveyor.txt
@@ -1,6 +1,6 @@
 clone_script:
 - cmd: >-
-    git clone -q --branch=migrate-to-dotnet-core https://github.com/alphagov/notifications-net-client.git C:\projects\notifications-net-client
+    git clone -q --branch=master https://github.com/alphagov/notifications-net-client.git C:\projects\notifications-net-client
 
     IF NOT %pullId% == 0 git fetch origin pull/%pullid%/head:BRANCHNAME && git checkout BRANCHNAME
 environment:


### PR DESCRIPTION
## What -
Use master appveyor config rather than the migrate-to-dotnet-core branch as changes to the appveyor config file have been merged.
