### PR TITLE
Update the integration test to look for the right status

### DIFF
--- a/src/Notify.Tests/IntegrationTests/Assertions.cs
+++ b/src/Notify.Tests/IntegrationTests/Assertions.cs
@@ -39,7 +39,8 @@ namespace Notify.Tests.IntegrationTests
 				"permanent-failure",
 				"temporary-failure",
 				"technical-failure",
-				"accepted"
+				"accepted",
+				"received"
 			};
 			CollectionAssert.Contains(allowedStatusTypes, notificationStatus);
 


### PR DESCRIPTION
When a letter is created with a test api key the status of the notification is set to received.
