### PR TITLE
Add new noti statuses

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,5 @@
 <!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
 - [x] I’ve used the pull request template
 - [ ] I’ve written unit tests for these changes
-- [ ] I’ve update the documentation (in `README.md and CONTRIBUTING.md`)
+- [ ] I’ve update the documentation (in `README.md, CHANGELOG.md and CONTRIBUTING.md`)
 - [ ] I’ve bumped the version number (in `src/Notify/Notify.csproj`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.0.1] - 2018-03-29
+
+* Add `pending-virus-check` and `virus-scan-failed` to statuses
+
+## [2.0.0] - 2018-02-09
+
+* Migrate to .Net core 2.0.0 and .Net framework 4.6.2
+
 ## [1.6.0] - 2017-11-15
 ## Changed
 

--- a/src/Notify.Tests/IntegrationTests/Assertions.cs
+++ b/src/Notify.Tests/IntegrationTests/Assertions.cs
@@ -40,7 +40,9 @@ namespace Notify.Tests.IntegrationTests
 				"temporary-failure",
 				"technical-failure",
 				"accepted",
-				"received"
+				"received",
+				"pending-virus-check",
+				"virus-scan-failed"
 			};
 			CollectionAssert.Contains(allowedStatusTypes, notificationStatus);
 

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
## What -
Occasional failures of the integration test due to new virus states which will block deployment so these have been added in: `pending-virus-check` and `virus-scan-failed`

