### PR TITLE
Implement interface

### DIFF
--- a/src/Notify/Client/NotificationClient.cs
+++ b/src/Notify/Client/NotificationClient.cs
@@ -13,7 +13,7 @@ using System.Net.Http;
 
 namespace Notify.Client
 {
-    public class NotificationClient : BaseClient
+    public class NotificationClient : BaseClient, INotificationClient
     {
         public string GET_RECEIVED_TEXTS_URL = "v2/received-text-messages";
         public string GET_NOTIFICATION_URL = "v2/notifications/";

--- a/src/Notify/Interfaces/INotificationClient.cs
+++ b/src/Notify/Interfaces/INotificationClient.cs
@@ -8,10 +8,10 @@ namespace Notify.Interfaces
     {
         Notification GetNotificationById(string notificationId);
 
-        List<Notification> GetNotifications(string templateType = "", string status = "");
+        NotificationList GetNotifications(string templateType = "", string status = "", string reference = "", string olderThanId = "");
 
-        SmsNotificationResponse SendSms(string mobileNumber, string templateId, Dictionary<string, dynamic> personalisation = null);
+        SmsNotificationResponse SendSms(string mobileNumber, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string smsSenderId = null);
 
-        EmailNotificationResponse SendEmail(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null);
+        EmailNotificationResponse SendEmail(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string emailReplyToId = null);
     }
 }

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
The NotificationClient did not implement the INotificationClient interface. Being unable to use an interface in the place of the NotificationClient makes unit testing rather painful, as we have to instead mock the IHttpClient.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes 
  **I dont feel this is applicable as no functional code has changed**
- [ ] I’ve update the documentation (in `README.md, CHANGELOG.md and CONTRIBUTING.md`) 
   **I am unsure if any doccumentation would need to change as the usage of the NotificationClient is unchanged**
- [x] I’ve bumped the version number (in `src/Notify/Notify.csproj`)
