### PR TITLE
Fix wrong method name in send email example

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -186,7 +186,7 @@ EmailNotificationResponse response = client.SendEmail(emailAddress, templateId, 
 ```
 
 ```csharp
-client.SendSms(
+client.SendEmail(
     emailAddress: "sender@something.com",
     templateId: "f33517ff-2a88-4f6e-b855-c550268ce08a"
 );


### PR DESCRIPTION
## What problem does the pull request solve?

Documentation was incorrect. Looks like it was copied from the text message section.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/Notify/Notify.csproj`)
