### PR TITLE
Implemented asynchronous version of Notify API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.5.0] - 2018-02-14
+
+* Implement asynchronous versions of the NotificationClient methods
+
 ## [2.4.0] - 2018-02-11
 
 * Add an optional `postage` argument to `SendPrecompiledLetter`.

--- a/src/Notify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
+++ b/src/Notify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
@@ -1,0 +1,479 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Notify.Client;
+using Notify.Exceptions;
+using Notify.Interfaces;
+using Notify.Models;
+using Notify.Models.Responses;
+using NUnit.Framework;
+
+namespace Notify.Tests.IntegrationTests
+{
+	[TestFixture]
+	public class NotificationClientAsyncIntegrationTests
+	{
+		private NotificationClient client;
+
+		private readonly String NOTIFY_API_URL = Environment.GetEnvironmentVariable("NOTIFY_API_URL");
+		private readonly String API_KEY = Environment.GetEnvironmentVariable("API_KEY");
+		private readonly String API_SENDING_KEY = Environment.GetEnvironmentVariable("API_SENDING_KEY");
+
+		private readonly String FUNCTIONAL_TEST_NUMBER = Environment.GetEnvironmentVariable("FUNCTIONAL_TEST_NUMBER");
+		private readonly String FUNCTIONAL_TEST_EMAIL = Environment.GetEnvironmentVariable("FUNCTIONAL_TEST_EMAIL");
+
+		private readonly String EMAIL_TEMPLATE_ID = Environment.GetEnvironmentVariable("EMAIL_TEMPLATE_ID");
+		private readonly String SMS_TEMPLATE_ID = Environment.GetEnvironmentVariable("SMS_TEMPLATE_ID");
+		private readonly String LETTER_TEMPLATE_ID = Environment.GetEnvironmentVariable("LETTER_TEMPLATE_ID");
+		private readonly String EMAIL_REPLY_TO_ID = Environment.GetEnvironmentVariable("EMAIL_REPLY_TO_ID");
+		private readonly String SMS_SENDER_ID = Environment.GetEnvironmentVariable("SMS_SENDER_ID");
+		private readonly String INBOUND_SMS_QUERY_KEY = Environment.GetEnvironmentVariable("INBOUND_SMS_QUERY_KEY");
+
+		private String smsNotificationId;
+		private String emailNotificationId;
+		private String letterNotificationId;
+
+		const String TEST_TEMPLATE_SMS_BODY = "Hello ((name))\r\n\r\nFunctional Tests make our world a better place";
+		const String TEST_SMS_BODY = "Hello someone\n\nFunctional Tests make our world a better place";
+
+		const String TEST_TEMPLATE_EMAIL_BODY = "Hello ((name))\r\n\r\nFunctional test help make our world a better place";
+		const String TEST_EMAIL_BODY = "Hello someone\r\n\r\nFunctional test help make our world a better place";
+		const String TEST_EMAIL_SUBJECT = "Functional Tests are good";
+
+		const String TEST_LETTER_BODY = "Hello Foo";
+		const String TEST_LETTER_SUBJECT = "Main heading";
+
+        [SetUp]
+		[Test, Category("Integration/NotificationClientAsync")]
+		public void SetUp()
+		{
+			this.client = new NotificationClient(NOTIFY_API_URL, API_KEY);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task SendSmsTestWithPersonalisation()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			SmsNotificationResponse response =
+				await this.client.SendSmsAsync(FUNCTIONAL_TEST_NUMBER, SMS_TEMPLATE_ID, personalisation, "sample-test-ref");
+			this.smsNotificationId = response.id;
+			Assert.IsNotNull(response);
+			Assert.AreEqual(response.content.body, TEST_SMS_BODY);
+
+			Assert.IsNotNull(response.reference);
+			Assert.AreEqual(response.reference, "sample-test-ref");
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetSMSNotificationWithIdReturnsNotification()
+		{
+			await SendSmsTestWithPersonalisation();
+			Notification notification = await this.client.GetNotificationByIdAsync(this.smsNotificationId);
+
+			Assert.IsNotNull(notification);
+			Assert.IsNotNull(notification.id);
+			Assert.AreEqual(notification.id, this.smsNotificationId);
+
+			Assert.IsNotNull(notification.body);
+			Assert.AreEqual(notification.body, TEST_SMS_BODY);
+
+			Assert.IsNotNull(notification.reference);
+			Assert.AreEqual(notification.reference, "sample-test-ref");
+
+			NotifyAssertions.AssertNotification(notification);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task SendEmailTestWithPersonalisation()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			EmailNotificationResponse response =
+				await this.client.SendEmailAsync(FUNCTIONAL_TEST_EMAIL, EMAIL_TEMPLATE_ID, personalisation);
+			this.emailNotificationId = response.id;
+
+			Assert.IsNotNull(response);
+			Assert.AreEqual(response.content.body, TEST_EMAIL_BODY);
+			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetEmailNotificationWithIdReturnsNotification()
+		{
+			await SendEmailTestWithPersonalisation();
+			Notification notification = await this.client.GetNotificationByIdAsync(this.emailNotificationId);
+			Assert.IsNotNull(notification);
+			Assert.IsNotNull(notification.id);
+			Assert.AreEqual(notification.id, this.emailNotificationId);
+
+			Assert.IsNotNull(notification.body);
+			Assert.AreEqual(notification.body, TEST_EMAIL_BODY);
+			Assert.IsNotNull(notification.subject);
+			Assert.AreEqual(notification.subject, TEST_EMAIL_SUBJECT);
+
+			NotifyAssertions.AssertNotification(notification);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task SendLetterTestWithPersonalisation()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "address_line_1", "Foo" },
+				{ "address_line_2", "Bar" },
+				{ "postcode", "Baz" }
+			};
+
+			LetterNotificationResponse response =
+				await this.client.SendLetterAsync(LETTER_TEMPLATE_ID, personalisation);
+
+			this.letterNotificationId = response.id;
+
+			Assert.IsNotNull(response);
+
+			Assert.AreEqual(response.content.body, TEST_LETTER_BODY);
+			Assert.AreEqual(response.content.subject, TEST_LETTER_SUBJECT);
+
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetLetterNotificationWithIdReturnsNotification()
+		{
+			await SendLetterTestWithPersonalisation();
+			Notification notification = await this.client.GetNotificationByIdAsync(this.letterNotificationId);
+
+			Assert.IsNotNull(notification);
+			Assert.IsNotNull(notification.id);
+			Assert.AreEqual(notification.id, this.letterNotificationId);
+
+			Assert.IsNotNull(notification.body);
+			Assert.AreEqual(notification.body, TEST_LETTER_BODY);
+
+			Assert.IsNotNull(notification.subject);
+			Assert.AreEqual(notification.subject, TEST_LETTER_SUBJECT);
+
+			NotifyAssertions.AssertNotification(notification);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task SendPrecompiledLetterTest()
+		{
+
+			string reference = System.Guid.NewGuid().ToString();
+			string postage = "first";
+                        byte[] pdfContents;
+                        try
+                        {
+                            pdfContents = File.ReadAllBytes("../../../IntegrationTests/test_files/one_page_pdf.pdf");
+                        }
+                        catch (DirectoryNotFoundException)
+                        {
+                            pdfContents = File.ReadAllBytes("IntegrationTests/test_files/one_page_pdf.pdf");
+                        }
+
+			LetterNotificationResponse response = await this.client.SendPrecompiledLetterAsync(reference, pdfContents, postage);
+
+			Assert.IsNotNull(response.id);
+			Assert.AreEqual(response.reference, reference);
+			Assert.AreEqual(response.postage, postage);
+
+			Notification notification = await this.client.GetNotificationByIdAsync(response.id);
+
+			Assert.IsNotNull(notification);
+			Assert.IsNotNull(notification.id);
+			Assert.AreEqual(notification.id, response.id);
+
+			Assert.AreEqual(notification.reference, response.reference);
+			Assert.AreEqual(notification.postage, response.postage);
+
+			NotifyAssertions.AssertNotification(notification);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task SendEmailWithDocumentPersonalisationTest()
+		{
+			byte[] pdfContents;
+
+			try
+			{
+				pdfContents = File.ReadAllBytes("../../../IntegrationTests/test_files/one_page_pdf.pdf");
+			}
+			catch (DirectoryNotFoundException)
+			{
+				pdfContents = File.ReadAllBytes("IntegrationTests/test_files/one_page_pdf.pdf");
+			}
+
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", NotificationClient.PrepareUpload(pdfContents) }
+			};
+
+			EmailNotificationResponse response =
+				await this.client.SendEmailAsync(FUNCTIONAL_TEST_EMAIL, EMAIL_TEMPLATE_ID, personalisation);
+
+			Assert.IsNotNull(response.id);
+			Assert.IsNotNull(response.template.id);
+			Assert.IsNotNull(response.template.uri);
+			Assert.IsNotNull(response.template.version);
+			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
+			Assert.IsTrue(response.content.body.Contains("https://documents."));
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetAllNotifications()
+		{
+			NotificationList notificationsResponse = await this.client.GetNotificationsAsync();
+			Assert.IsNotNull(notificationsResponse);
+			Assert.IsNotNull(notificationsResponse.notifications);
+
+			List<Notification> notifications = notificationsResponse.notifications;
+
+			foreach (Notification notification in notifications)
+			{
+				NotifyAssertions.AssertNotification(notification);
+			}
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetReceivedTexts()
+		{
+			NotificationClient client_inbound = new NotificationClient(NOTIFY_API_URL, INBOUND_SMS_QUERY_KEY);
+			ReceivedTextListResponse receivedTextListResponse = await client_inbound.GetReceivedTextsAsync();
+			Assert.IsNotNull(receivedTextListResponse);
+			Assert.IsNotNull(receivedTextListResponse.receivedTexts);
+			Assert.IsTrue(receivedTextListResponse.receivedTexts.Count > 0);
+
+			List<ReceivedTextResponse> receivedTexts = receivedTextListResponse.receivedTexts;
+
+			foreach (ReceivedTextResponse receivedText in receivedTexts)
+			{
+				NotifyAssertions.AssertReceivedTextResponse(receivedText);
+			}
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public void GetNotificationWithInvalidIdRaisesClientException()
+		{
+			var ex = Assert.ThrowsAsync<NotifyClientException>(async () =>
+				await this.client.GetNotificationByIdAsync("fa5f0a6e-5293-49f1-b99f-3fade784382f")
+			);
+			Assert.That(ex.Message, Does.Contain("No result found"));
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public void GetTemplateWithInvalidIdRaisesClientException()
+		{
+			var ex = Assert.ThrowsAsync<NotifyClientException>(async () =>
+				await this.client.GetTemplateByIdAsync("invalid_id")
+			);
+			Assert.That(ex.Message, Does.Contain("id is not a valid UUID"));
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public void GetTemplateWithIdWithoutResultRaisesClientException()
+		{
+			var ex = Assert.ThrowsAsync<NotifyClientException>(async () =>
+				await this.client.GetTemplateByIdAsync("fa5f0a6e-5293-49f1-b99f-3fade784382f")
+			);
+			Assert.That(ex.Message, Does.Contain("No result found"));
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetAllTemplates()
+		{
+			TemplateList templateList = await this.client.GetAllTemplatesAsync();
+			Assert.IsNotNull(templateList);
+			Assert.IsTrue(templateList.templates.Count > 0);
+
+			foreach (TemplateResponse template in templateList.templates)
+			{
+				NotifyAssertions.AssertTemplateResponse(template);
+			}
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetAllSMSTemplates()
+		{
+			const String type = "sms";
+			TemplateList templateList = await this.client.GetAllTemplatesAsync(type);
+			Assert.IsNotNull(templateList);
+			Assert.IsTrue(templateList.templates.Count > 0);
+
+			foreach (TemplateResponse template in templateList.templates)
+			{
+				NotifyAssertions.AssertTemplateResponse(template, type);
+			}
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetAllEmailTemplates()
+		{
+			const String type = "email";
+			TemplateList templateList = await this.client.GetAllTemplatesAsync(type);
+			Assert.IsNotNull(templateList);
+			Assert.IsTrue(templateList.templates.Count > 0);
+
+			foreach (TemplateResponse template in templateList.templates)
+			{
+				NotifyAssertions.AssertTemplateResponse(template, type);
+			}
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public void GetAllInvalidTemplatesRaisesClientException()
+		{
+			const String type = "invalid";
+
+			var ex = Assert.ThrowsAsync<NotifyClientException>(async () => await this.client.GetAllTemplatesAsync(type));
+			Assert.That(ex.Message, Does.Contain("type invalid is not one of [sms, email, letter]"));
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetSMSTemplateWithId()
+		{
+			TemplateResponse template = await this.client.GetTemplateByIdAsync(SMS_TEMPLATE_ID);
+			Assert.AreEqual(template.id, SMS_TEMPLATE_ID);
+			Assert.AreEqual(template.body, TEST_TEMPLATE_SMS_BODY);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GetEmailTemplateWithId()
+		{
+			TemplateResponse template = await this.client.GetTemplateByIdAsync(EMAIL_TEMPLATE_ID);
+			Assert.AreEqual(template.id, EMAIL_TEMPLATE_ID);
+			Assert.AreEqual(template.body, TEST_TEMPLATE_EMAIL_BODY);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GenerateSMSPreviewWithPersonalisation()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			TemplatePreviewResponse response =
+				await this.client.GenerateTemplatePreviewAsync(SMS_TEMPLATE_ID, personalisation);
+
+			Assert.IsNotNull(response);
+			Assert.AreEqual(response.body, TEST_SMS_BODY);
+			Assert.AreEqual(response.subject, null);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task GenerateEmailPreviewWithPersonalisation()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			TemplatePreviewResponse response =
+				await this.client.GenerateTemplatePreviewAsync(EMAIL_TEMPLATE_ID, personalisation);
+
+			Assert.IsNotNull(response);
+			Assert.AreEqual(response.body, TEST_EMAIL_BODY);
+			Assert.AreEqual(response.subject, TEST_EMAIL_SUBJECT);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public void GenerateEmailPreviewWithMissingPersonalisationRaisesClientException()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "invalid", "personalisation" }
+			};
+
+			var ex = Assert.ThrowsAsync<NotifyClientException>(async () =>
+				await this.client.GenerateTemplatePreviewAsync(EMAIL_TEMPLATE_ID, personalisation)
+			);
+			Assert.That(ex.Message, Does.Contain("Missing personalisation: name"));
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task SendEmailTestServiceDefaultEmailReplyTo()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			EmailNotificationResponse response = await this.client.SendEmailAsync(FUNCTIONAL_TEST_EMAIL, EMAIL_TEMPLATE_ID, personalisation);
+			this.emailNotificationId = response.id;
+			Assert.IsNotNull(response);
+			Assert.AreEqual(response.content.body, TEST_EMAIL_BODY);
+			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task SendEmailTestSpecificEmailReplyTo()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			EmailNotificationResponse response = await this.client.SendEmailAsync(FUNCTIONAL_TEST_EMAIL, EMAIL_TEMPLATE_ID, personalisation, emailReplyToId: EMAIL_REPLY_TO_ID);
+			this.emailNotificationId = response.id;
+			Assert.IsNotNull(response);
+			Assert.AreEqual(response.content.body, TEST_EMAIL_BODY);
+			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public void SendEmailTestEmailReplyToNotPresent()
+		{
+			String fakeReplayToId = System.Guid.NewGuid().ToString();
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			var ex = Assert.ThrowsAsync<NotifyClientException>(async () => await this.client.SendEmailAsync(FUNCTIONAL_TEST_EMAIL, EMAIL_TEMPLATE_ID, personalisation, emailReplyToId: fakeReplayToId));
+			Assert.That(ex.Message, Does.Contain("email_reply_to_id " + fakeReplayToId));
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task SendEmailTestAllArguments()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			EmailNotificationResponse response = await this.client.SendEmailAsync(FUNCTIONAL_TEST_EMAIL, EMAIL_TEMPLATE_ID, personalisation, clientReference: "TestReference", emailReplyToId: EMAIL_REPLY_TO_ID);
+			this.emailNotificationId = response.id;
+			Assert.IsNotNull(response);
+			Assert.AreEqual(response.content.body, TEST_EMAIL_BODY);
+			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
+		}
+
+		[Test, Category("Integration/NotificationClientAsync")]
+		public async Task SendSmsTestWithPersonalisationAndSmsSenderId()
+		{
+			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+			{
+				{ "name", "someone" }
+			};
+
+			NotificationClient client_sending = new NotificationClient(NOTIFY_API_URL, API_SENDING_KEY);
+
+			SmsNotificationResponse response =
+				await client_sending.SendSmsAsync(FUNCTIONAL_TEST_NUMBER, SMS_TEMPLATE_ID, personalisation, "sample-test-ref", SMS_SENDER_ID);
+			this.smsNotificationId = response.id;
+			Assert.IsNotNull(response);
+			Assert.AreEqual(response.content.body, TEST_SMS_BODY);
+
+			Assert.IsNotNull(response.reference);
+			Assert.AreEqual(response.reference, "sample-test-ref");
+		}
+	}
+}

--- a/src/Notify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
+++ b/src/Notify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Notify.Client;
 using Notify.Exceptions;
+using Notify.Interfaces;
 using Notify.Models;
 using Notify.Models.Responses;
 using NUnit.Framework;
@@ -10,23 +11,23 @@ using NUnit.Framework;
 namespace Notify.Tests.IntegrationTests
 {
 	[TestFixture]
-	public class NotificationIntegrationClientTests
+	public class NotificationClientIntegrationTests
 	{
 		private NotificationClient client;
 
-		private String NOTIFY_API_URL = Environment.GetEnvironmentVariable("NOTIFY_API_URL");
-		private String API_KEY = Environment.GetEnvironmentVariable("API_KEY");
-		private String API_SENDING_KEY = Environment.GetEnvironmentVariable("API_SENDING_KEY");
+		private readonly String NOTIFY_API_URL = Environment.GetEnvironmentVariable("NOTIFY_API_URL");
+		private readonly String API_KEY = Environment.GetEnvironmentVariable("API_KEY");
+		private readonly String API_SENDING_KEY = Environment.GetEnvironmentVariable("API_SENDING_KEY");
 
-		private String FUNCTIONAL_TEST_NUMBER = Environment.GetEnvironmentVariable("FUNCTIONAL_TEST_NUMBER");
-		private String FUNCTIONAL_TEST_EMAIL = Environment.GetEnvironmentVariable("FUNCTIONAL_TEST_EMAIL");
+		private readonly String FUNCTIONAL_TEST_NUMBER = Environment.GetEnvironmentVariable("FUNCTIONAL_TEST_NUMBER");
+		private readonly String FUNCTIONAL_TEST_EMAIL = Environment.GetEnvironmentVariable("FUNCTIONAL_TEST_EMAIL");
 
-		private String EMAIL_TEMPLATE_ID = Environment.GetEnvironmentVariable("EMAIL_TEMPLATE_ID");
-		private String SMS_TEMPLATE_ID = Environment.GetEnvironmentVariable("SMS_TEMPLATE_ID");
-		private String LETTER_TEMPLATE_ID = Environment.GetEnvironmentVariable("LETTER_TEMPLATE_ID");
-		private String EMAIL_REPLY_TO_ID = Environment.GetEnvironmentVariable("EMAIL_REPLY_TO_ID");
-		private String SMS_SENDER_ID = Environment.GetEnvironmentVariable("SMS_SENDER_ID");
-		private String INBOUND_SMS_QUERY_KEY = Environment.GetEnvironmentVariable("INBOUND_SMS_QUERY_KEY");
+		private readonly String EMAIL_TEMPLATE_ID = Environment.GetEnvironmentVariable("EMAIL_TEMPLATE_ID");
+		private readonly String SMS_TEMPLATE_ID = Environment.GetEnvironmentVariable("SMS_TEMPLATE_ID");
+		private readonly String LETTER_TEMPLATE_ID = Environment.GetEnvironmentVariable("LETTER_TEMPLATE_ID");
+		private readonly String EMAIL_REPLY_TO_ID = Environment.GetEnvironmentVariable("EMAIL_REPLY_TO_ID");
+		private readonly String SMS_SENDER_ID = Environment.GetEnvironmentVariable("SMS_SENDER_ID");
+		private readonly String INBOUND_SMS_QUERY_KEY = Environment.GetEnvironmentVariable("INBOUND_SMS_QUERY_KEY");
 
 		private String smsNotificationId;
 		private String emailNotificationId;
@@ -43,13 +44,13 @@ namespace Notify.Tests.IntegrationTests
 		const String TEST_LETTER_SUBJECT = "Main heading";
 
 		[SetUp]
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SetUp()
 		{
 			this.client = new NotificationClient(NOTIFY_API_URL, API_KEY);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendSmsTestWithPersonalisation()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -67,7 +68,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.AreEqual(response.reference, "sample-test-ref");
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetSMSNotificationWithIdReturnsNotification()
 		{
 			SendSmsTestWithPersonalisation();
@@ -86,7 +87,7 @@ namespace Notify.Tests.IntegrationTests
 			NotifyAssertions.AssertNotification(notification);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendEmailTestWithPersonalisation()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -103,7 +104,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetEmailNotificationWithIdReturnsNotification()
 		{
 			SendEmailTestWithPersonalisation();
@@ -120,7 +121,7 @@ namespace Notify.Tests.IntegrationTests
 			NotifyAssertions.AssertNotification(notification);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendLetterTestWithPersonalisation()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -142,7 +143,7 @@ namespace Notify.Tests.IntegrationTests
 
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetLetterNotificationWithIdReturnsNotification()
 		{
 			SendLetterTestWithPersonalisation();
@@ -161,7 +162,7 @@ namespace Notify.Tests.IntegrationTests
 			NotifyAssertions.AssertNotification(notification);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendPrecompiledLetterTest()
 		{
 
@@ -195,7 +196,7 @@ namespace Notify.Tests.IntegrationTests
 			NotifyAssertions.AssertNotification(notification);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendEmailWithDocumentPersonalisationTest()
 		{
 			byte[] pdfContents;
@@ -225,7 +226,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.IsTrue(response.content.body.Contains("https://documents."));
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetAllNotifications()
 		{
 			NotificationList notificationsResponse = this.client.GetNotifications();
@@ -241,10 +242,10 @@ namespace Notify.Tests.IntegrationTests
 
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetReceivedTexts()
 		{
-			NotificationClient client_inbound = new NotificationClient(NOTIFY_API_URL, INBOUND_SMS_QUERY_KEY);
+			INotificationClient client_inbound = new NotificationClient(NOTIFY_API_URL, INBOUND_SMS_QUERY_KEY);
 			ReceivedTextListResponse receivedTextListResponse = client_inbound.GetReceivedTexts();
 			Assert.IsNotNull(receivedTextListResponse);
 			Assert.IsNotNull(receivedTextListResponse.receivedTexts);
@@ -258,7 +259,7 @@ namespace Notify.Tests.IntegrationTests
 			}
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetNotificationWithInvalidIdRaisesClientException()
 		{
 			var ex = Assert.Throws<NotifyClientException>(() =>
@@ -267,7 +268,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.That(ex.Message, Does.Contain("No result found"));
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetTemplateWithInvalidIdRaisesClientException()
 		{
 			var ex = Assert.Throws<NotifyClientException>(() =>
@@ -276,7 +277,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.That(ex.Message, Does.Contain("id is not a valid UUID"));
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetTemplateWithIdWithoutResultRaisesClientException()
 		{
 			var ex = Assert.Throws<NotifyClientException>(() =>
@@ -285,7 +286,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.That(ex.Message, Does.Contain("No result found"));
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetAllTemplates()
 		{
 			TemplateList templateList = this.client.GetAllTemplates();
@@ -298,7 +299,7 @@ namespace Notify.Tests.IntegrationTests
 			}
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetAllSMSTemplates()
 		{
 			const String type = "sms";
@@ -312,7 +313,7 @@ namespace Notify.Tests.IntegrationTests
 			}
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetAllEmailTemplates()
 		{
 			const String type = "email";
@@ -326,7 +327,7 @@ namespace Notify.Tests.IntegrationTests
 			}
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetAllInvalidTemplatesRaisesClientException()
 		{
 			const String type = "invalid";
@@ -335,7 +336,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.That(ex.Message, Does.Contain("type invalid is not one of [sms, email, letter]"));
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetSMSTemplateWithId()
 		{
 			TemplateResponse template = this.client.GetTemplateById(SMS_TEMPLATE_ID);
@@ -343,7 +344,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.AreEqual(template.body, TEST_TEMPLATE_SMS_BODY);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GetEmailTemplateWithId()
 		{
 			TemplateResponse template = this.client.GetTemplateById(EMAIL_TEMPLATE_ID);
@@ -351,7 +352,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.AreEqual(template.body, TEST_TEMPLATE_EMAIL_BODY);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GenerateSMSPreviewWithPersonalisation()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -367,7 +368,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.AreEqual(response.subject, null);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GenerateEmailPreviewWithPersonalisation()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -383,7 +384,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.AreEqual(response.subject, TEST_EMAIL_SUBJECT);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void GenerateEmailPreviewWithMissingPersonalisationRaisesClientException()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -397,7 +398,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.That(ex.Message, Does.Contain("Missing personalisation: name"));
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendEmailTestServiceDefaultEmailReplyTo()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -412,7 +413,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendEmailTestSpecificEmailReplyTo()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -427,7 +428,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendEmailTestEmailReplyToNotPresent()
 		{
 			String fakeReplayToId = System.Guid.NewGuid().ToString();
@@ -440,7 +441,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.That(ex.Message, Does.Contain("email_reply_to_id " + fakeReplayToId));
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendEmailTestAllArguments()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -455,7 +456,7 @@ namespace Notify.Tests.IntegrationTests
 			Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
 		}
 
-		[Test, Category("Integration")]
+		[Test, Category("Integration/NotificationClient")]
 		public void SendSmsTestWithPersonalisationAndSmsSenderId()
 		{
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>

--- a/src/Notify.Tests/UnitTests/NotificationClientAsyncUnitTests.cs
+++ b/src/Notify.Tests/UnitTests/NotificationClientAsyncUnitTests.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Notify.Client;
 using Notify.Exceptions;
+using Notify.Interfaces;
 using Notify.Models;
 using Notify.Models.Responses;
 using NUnit.Framework;
@@ -18,7 +19,7 @@ using NUnit.Framework;
 namespace Notify.Tests.UnitTests
 {
     [TestFixture]
-    public class NotificationUnitClientTests
+    public class NotificationClientAsyncUnitTests
     {
         private Mock<HttpMessageHandler> handler;
         private NotificationClient client;
@@ -39,165 +40,165 @@ namespace Notify.Tests.UnitTests
             client = null;
         }
 
-        [Test, Category("Unit/NotificationClient")]
+        [Test, Category("Unit/NotificationClientAsync")]
         public void CreateNotificationClientWithInvalidApiKeyFails()
         {
             Assert.Throws<NotifyAuthException>(() => new NotificationClient("someinvalidkey"));
         }
 
-        [Test, Category("Unit/NotificationClient")]
+        [Test, Category("Unit/NotificationClientAsync")]
         public void CreateNotificationClientWithEmptyApiKeyFails()
         {
             Assert.Throws<NotifyAuthException>(() => new NotificationClient(""));
         }
 
-        [Test, Category("Unit/NotificationClient")]
+        [Test, Category("Unit/NotificationClientAsync")]
         public void GetNonJsonResponseHandlesException()
         {
             MockRequest("non json response",
                 client.GET_ALL_NOTIFICATIONS_URL,
                 AssertValidRequest, status: HttpStatusCode.NotFound);
 
-            var ex = Assert.Throws<NotifyClientException>(() => client.GetNotifications());
+            var ex = Assert.ThrowsAsync<NotifyClientException>(async () => await client.GetNotificationsAsync());
             Assert.That(ex.Message, Does.Contain("Status code 404. Error: non json response"));
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetNotificationWithIdCreatesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetNotificationWithIdCreatesExpectedRequest()
         {
             MockRequest(Constants.fakeNotificationJson,
                 client.GET_NOTIFICATION_URL + Constants.fakeNotificationId,
                 AssertValidRequest);
 
-            client.GetNotificationById(Constants.fakeNotificationId);
+            await client.GetNotificationByIdAsync(Constants.fakeNotificationId);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllNotificationsCreatesExpectedResult()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllNotificationsCreatesExpectedResult()
         {
             MockRequest(Constants.fakeNotificationsJson,
                 client.GET_ALL_NOTIFICATIONS_URL,
                 AssertValidRequest);
 
-            client.GetNotifications();
+            await client.GetNotificationsAsync();
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllNotificationsWithStatusCreatesExpectedResult()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllNotificationsWithStatusCreatesExpectedResult()
         {
             MockRequest(Constants.fakeNotificationsJson,
                 client.GET_ALL_NOTIFICATIONS_URL + "?status=sending",
                 AssertValidRequest);
 
-            client.GetNotifications(status: "sending");
+            await client.GetNotificationsAsync(status: "sending");
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllNotificationsWithReferenceCreatesExpectedResult()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllNotificationsWithReferenceCreatesExpectedResult()
         {
             MockRequest(Constants.fakeNotificationsJson,
                 client.GET_ALL_NOTIFICATIONS_URL + "?reference=foo",
                 AssertValidRequest);
 
-            client.GetNotifications(reference: "foo");
+            await client.GetNotificationsAsync(reference: "foo");
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllSmsNotificationsWithStatusAndReferenceWithCreatesExpectedResult()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllSmsNotificationsWithStatusAndReferenceWithCreatesExpectedResult()
         {
             MockRequest(Constants.fakeNotificationsJson,
                 client.GET_ALL_NOTIFICATIONS_URL + "?template_type=sms&status=sending&reference=foo",
                 AssertValidRequest);
 
-            client.GetNotifications(templateType: "sms", status: "sending", reference: "foo");
+            await client.GetNotificationsAsync(templateType: "sms", status: "sending", reference: "foo");
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllSmsNotificationsCreatesExpectedResult()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllSmsNotificationsCreatesExpectedResult()
         {
             MockRequest(Constants.fakeSmsNotificationResponseJson,
                 client.GET_ALL_NOTIFICATIONS_URL + "?template_type=sms",
                 AssertValidRequest);
 
-            client.GetNotifications(templateType: "sms");
+            await client.GetNotificationsAsync(templateType: "sms");
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllEmailNotificationsCreatesExpectedResult()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllEmailNotificationsCreatesExpectedResult()
         {
             MockRequest(Constants.fakeEmailNotificationResponseJson,
                 client.GET_ALL_NOTIFICATIONS_URL + "?template_type=email",
                 AssertValidRequest);
 
-            client.GetNotifications(templateType: "email");
+            await client.GetNotificationsAsync(templateType: "email");
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllLetterNotificationsCreatesExpectedResult()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllLetterNotificationsCreatesExpectedResult()
         {
             MockRequest(Constants.fakeEmailNotificationResponseJson,
                 client.GET_ALL_NOTIFICATIONS_URL + "?template_type=letter",
                 AssertValidRequest);
 
-            client.GetNotifications(templateType: "letter");
+            await client.GetNotificationsAsync(templateType: "letter");
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetTemplateWithIdCreatesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetTemplateWithIdCreatesExpectedRequest()
         {
             MockRequest(Constants.fakeTemplateResponseJson,
                 client.GET_TEMPLATE_URL + Constants.fakeTemplateId,
                 AssertValidRequest);
 
-            client.GetTemplateByIdAndVersion(Constants.fakeTemplateId);
+            await client.GetTemplateByIdAndVersionAsync(Constants.fakeTemplateId);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetTemplateWithIdAndVersionCreatesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetTemplateWithIdAndVersionCreatesExpectedRequest()
         {
             MockRequest(Constants.fakeTemplateResponseJson,
                 client.GET_TEMPLATE_URL + Constants.fakeTemplateId + client.VERSION_PARAM + "2",
                 AssertValidRequest);
 
-            client.GetTemplateByIdAndVersion(Constants.fakeTemplateId, 2);
+            await client.GetTemplateByIdAndVersionAsync(Constants.fakeTemplateId, 2);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetNotificationWithIdReceivesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetNotificationWithIdReceivesExpectedResponse()
         {
             var expectedResponse = JsonConvert.DeserializeObject<Notification>(Constants.fakeNotificationJson);
 
             MockRequest(Constants.fakeNotificationJson);
 
-            var responseNotification = client.GetNotificationById(Constants.fakeNotificationId);
+            var responseNotification = await client.GetNotificationByIdAsync(Constants.fakeNotificationId);
             Assert.IsTrue(expectedResponse.Equals(responseNotification));
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetTemplateWithIdReceivesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetTemplateWithIdReceivesExpectedResponse()
         {
             var expectedResponse = JsonConvert.DeserializeObject<TemplateResponse>(Constants.fakeTemplateResponseJson);
 
             MockRequest(Constants.fakeTemplateResponseJson);
 
-            var responseTemplate = client.GetTemplateById(Constants.fakeTemplateId);
+            var responseTemplate = await client.GetTemplateByIdAsync(Constants.fakeTemplateId);
             Assert.IsTrue(expectedResponse.Equals(responseTemplate));
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetTemplateWithIdAndVersionReceivesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetTemplateWithIdAndVersionReceivesExpectedResponse()
         {
             var expectedResponse =
                 JsonConvert.DeserializeObject<TemplateResponse>(Constants.fakeTemplateResponseJson);
 
             MockRequest(Constants.fakeTemplateResponseJson);
 
-            var responseTemplate = client.GetTemplateByIdAndVersion(Constants.fakeTemplateId, 2);
+            var responseTemplate = await client.GetTemplateByIdAndVersionAsync(Constants.fakeTemplateId, 2);
             Assert.IsTrue(expectedResponse.Equals(responseTemplate));
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GenerateTemplatePreviewGeneratesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GenerateTemplatePreviewGeneratesExpectedRequest()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic> {
                     { "name", "someone" }
@@ -211,11 +212,11 @@ namespace Notify.Tests.UnitTests
             MockRequest(Constants.fakeTemplatePreviewResponseJson,
                 client.GET_TEMPLATE_URL + Constants.fakeTemplateId + "/preview", AssertValidRequest, HttpMethod.Post);
 
-            var response = client.GenerateTemplatePreview(Constants.fakeTemplateId, personalisation);
+            var response = await client.GenerateTemplatePreviewAsync(Constants.fakeTemplateId, personalisation);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GenerateTemplatePreviewReceivesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GenerateTemplatePreviewReceivesExpectedResponse()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic> {
                     { "name", "someone" }
@@ -232,61 +233,61 @@ namespace Notify.Tests.UnitTests
                 HttpMethod.Post,
                 AssertGetExpectedContent, expected.ToString(Formatting.None));
 
-            client.GenerateTemplatePreview(Constants.fakeTemplateId, personalisation);
+            await client.GenerateTemplatePreviewAsync(Constants.fakeTemplateId, personalisation);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllTemplatesCreatesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllTemplatesCreatesExpectedRequest()
         {
             MockRequest(Constants.fakeTemplateListResponseJson,
                  client.GET_ALL_TEMPLATES_URL, AssertValidRequest);
 
-            client.GetAllTemplates();
+            await client.GetAllTemplatesAsync();
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllTemplatesBySmsTypeCreatesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllTemplatesBySmsTypeCreatesExpectedRequest()
         {
             const string type = "sms";
             MockRequest(Constants.fakeTemplateSmsListResponseJson,
                          client.GET_ALL_TEMPLATES_URL+ client.TYPE_PARAM + type, AssertValidRequest);
 
-            client.GetAllTemplates(type);
+            await client.GetAllTemplatesAsync(type);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllTemplatesByEmailTypeCreatesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllTemplatesByEmailTypeCreatesExpectedRequest()
         {
             const string type = "email";
 
             MockRequest(Constants.fakeTemplateEmailListResponseJson,
                          client.GET_ALL_TEMPLATES_URL+ client.TYPE_PARAM + type, AssertValidRequest);
 
-            client.GetAllTemplates(type);
+            await client.GetAllTemplatesAsync(type);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllTemplatesForEmptyListReceivesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllTemplatesForEmptyListReceivesExpectedResponse()
         {
             var expectedResponse = JsonConvert.DeserializeObject<TemplateList>(Constants.fakeTemplateEmptyListResponseJson);
 
                MockRequest(Constants.fakeTemplateEmptyListResponseJson);
 
-            TemplateList templateList = client.GetAllTemplates();
+            TemplateList templateList = await client.GetAllTemplatesAsync();
 
             List<TemplateResponse> templates = templateList.templates;
 
             Assert.IsTrue(templates.Count == 0);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllTemplatesReceivesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllTemplatesReceivesExpectedResponse()
         {
             TemplateList expectedResponse = JsonConvert.DeserializeObject<TemplateList>(Constants.fakeTemplateListResponseJson);
 
             MockRequest(Constants.fakeTemplateListResponseJson);
 
-            TemplateList templateList = client.GetAllTemplates();
+            TemplateList templateList = await client.GetAllTemplatesAsync();
 
             List<TemplateResponse> templates = templateList.templates;
 
@@ -297,8 +298,8 @@ namespace Notify.Tests.UnitTests
             }
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllTemplatesBySmsTypeReceivesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllTemplatesBySmsTypeReceivesExpectedResponse()
         {
             const string type = "sms";
 
@@ -308,7 +309,7 @@ namespace Notify.Tests.UnitTests
             MockRequest(Constants.fakeTemplateSmsListResponseJson,
                          client.GET_ALL_TEMPLATES_URL + client.TYPE_PARAM + type, AssertValidRequest);
 
-            TemplateList templateList = client.GetAllTemplates(type);
+            TemplateList templateList = await client.GetAllTemplatesAsync(type);
 
             List<TemplateResponse> templates = templateList.templates;
 
@@ -319,8 +320,8 @@ namespace Notify.Tests.UnitTests
             }
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllTemplatesByEmailTypeReceivesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllTemplatesByEmailTypeReceivesExpectedResponse()
         {
             const string type = "email";
 
@@ -330,7 +331,7 @@ namespace Notify.Tests.UnitTests
             MockRequest(Constants.fakeTemplateEmailListResponseJson,
                          client.GET_ALL_TEMPLATES_URL + client.TYPE_PARAM + type, AssertValidRequest);
 
-            TemplateList templateList = client.GetAllTemplates(type);
+            TemplateList templateList = await client.GetAllTemplatesAsync(type);
 
             List<TemplateResponse> templates = templateList.templates;
 
@@ -341,17 +342,17 @@ namespace Notify.Tests.UnitTests
             }
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllReceivedTextsCreatesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllReceivedTextsCreatesExpectedRequest()
         {
             MockRequest(Constants.fakeReceivedTextListResponseJson,
                  client.GET_RECEIVED_TEXTS_URL, AssertValidRequest);
 
-            client.GetReceivedTexts();
+            await client.GetReceivedTextsAsync();
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void GetAllReceivedTextsReceivesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task GetAllReceivedTextsReceivesExpectedResponse()
         {
             MockRequest(Constants.fakeReceivedTextListResponseJson,
                  client.GET_RECEIVED_TEXTS_URL, AssertValidRequest);
@@ -362,7 +363,7 @@ namespace Notify.Tests.UnitTests
             MockRequest(Constants.fakeReceivedTextListResponseJson,
                          client.GET_RECEIVED_TEXTS_URL, AssertValidRequest);
 
-            ReceivedTextListResponse receivedTextList = client.GetReceivedTexts();
+            ReceivedTextListResponse receivedTextList = await client.GetReceivedTextsAsync();
 
             List<ReceivedTextResponse> receivedTexts = receivedTextList.receivedTexts;
 
@@ -373,8 +374,8 @@ namespace Notify.Tests.UnitTests
             }
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendSmsNotificationGeneratesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendSmsNotificationGeneratesExpectedRequest()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
                 {
@@ -393,11 +394,11 @@ namespace Notify.Tests.UnitTests
                 HttpMethod.Post,
                 AssertGetExpectedContent, expected.ToString(Formatting.None));
 
-            SmsNotificationResponse response = client.SendSms(Constants.fakePhoneNumber, Constants.fakeTemplateId, personalisation);
+            SmsNotificationResponse response = await client.SendSmsAsync(Constants.fakePhoneNumber, Constants.fakeTemplateId, personalisation);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendSmsNotificationGeneratesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendSmsNotificationGeneratesExpectedResponse()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
                 {
@@ -407,13 +408,13 @@ namespace Notify.Tests.UnitTests
 
             MockRequest(Constants.fakeSmsNotificationResponseJson);
 
-            SmsNotificationResponse actualResponse = client.SendSms(Constants.fakePhoneNumber, Constants.fakeTemplateId, personalisation);
+            SmsNotificationResponse actualResponse = await client.SendSmsAsync(Constants.fakePhoneNumber, Constants.fakeTemplateId, personalisation);
 
             Assert.IsTrue(expectedResponse.Equals(actualResponse));
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendEmailNotificationGeneratesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendEmailNotificationGeneratesExpectedRequest()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
                 {
@@ -433,11 +434,11 @@ namespace Notify.Tests.UnitTests
                 HttpMethod.Post,
                 AssertGetExpectedContent, expected.ToString(Formatting.None));
 
-            EmailNotificationResponse response = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+            EmailNotificationResponse response = await client.SendEmailAsync(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendEmailNotificationWithDocumentGeneratesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendEmailNotificationWithDocumentGeneratesExpectedRequest()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
                 {
@@ -465,10 +466,10 @@ namespace Notify.Tests.UnitTests
                 HttpMethod.Post,
                 AssertGetExpectedContent, expected.ToString(Formatting.None));
 
-            EmailNotificationResponse response = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+            EmailNotificationResponse response = await client.SendEmailAsync(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
         }
 
-        [Test, Category("Unit/NotificationClient")]
+        [Test, Category("Unit/NotificationClientAsync")]
         public void PrepareUploadWithLargeDocumentGeneratesAnError()
         {
             Assert.That(
@@ -477,8 +478,8 @@ namespace Notify.Tests.UnitTests
                     );
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendEmailNotificationGeneratesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendEmailNotificationGeneratesExpectedResponse()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
                 {
@@ -488,14 +489,14 @@ namespace Notify.Tests.UnitTests
 
             MockRequest(Constants.fakeEmailNotificationResponseJson);
 
-            EmailNotificationResponse actualResponse = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+            EmailNotificationResponse actualResponse = await client.SendEmailAsync(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
 
             Assert.IsTrue(expectedResponse.Equals(actualResponse));
 
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendLetterNotificationGeneratesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendLetterNotificationGeneratesExpectedRequest()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
                 {
@@ -516,11 +517,11 @@ namespace Notify.Tests.UnitTests
                 HttpMethod.Post,
                 AssertGetExpectedContent, expected.ToString(Formatting.None));
 
-            LetterNotificationResponse response = client.SendLetter(Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+            LetterNotificationResponse response = await client.SendLetterAsync(Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendLetterNotificationGeneratesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendLetterNotificationGeneratesExpectedResponse()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
                 {
@@ -532,14 +533,14 @@ namespace Notify.Tests.UnitTests
 
             MockRequest(Constants.fakeLetterNotificationResponseJson);
 
-            LetterNotificationResponse actualResponse = client.SendLetter(Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+            LetterNotificationResponse actualResponse = await client.SendLetterAsync(Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
 
             Assert.IsTrue(expectedResponse.Equals(actualResponse));
 
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendPrecompiledLetterNotificationGeneratesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendPrecompiledLetterNotificationGeneratesExpectedRequest()
         {
             JObject expected = new JObject
             {
@@ -553,47 +554,23 @@ namespace Notify.Tests.UnitTests
                 HttpMethod.Post,
                 AssertGetExpectedContent, expected.ToString(Formatting.None));
 
-            LetterNotificationResponse response = client.SendPrecompiledLetter(
+            LetterNotificationResponse response = await client.SendPrecompiledLetterAsync(
                     Constants.fakeNotificationReference,
                     Encoding.UTF8.GetBytes("%PDF-1.5 testpdf")
             );
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendPrecompiledLetterNotificationGeneratesExpectedRequestWithPostage()
-        {
-            JObject expected = new JObject
-            {
-                { "reference", Constants.fakeNotificationReference },
-                { "content", "JVBERi0xLjUgdGVzdHBkZg==" },
-                { "postage", "first" }
-            };
-
-            MockRequest(Constants.fakeTemplatePreviewResponseJson,
-                client.SEND_LETTER_NOTIFICATION_URL,
-                AssertValidRequest,
-                HttpMethod.Post,
-                AssertGetExpectedContent, expected.ToString(Formatting.None));
-
-            LetterNotificationResponse response = client.SendPrecompiledLetter(
-                    Constants.fakeNotificationReference,
-                    Encoding.UTF8.GetBytes("%PDF-1.5 testpdf"),
-                    "first"
-            );
-        }
-
-        [Test, Category("Unit/NotificationClient")]
-        public void SendPrecompiledLetterNotificationGeneratesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendPrecompiledLetterNotificationGeneratesExpectedResponse()
         {
             LetterNotificationResponse expectedResponse = JsonConvert.DeserializeObject<LetterNotificationResponse>(Constants.fakePrecompiledLetterNotificationResponseJson);
 
             MockRequest(Constants.fakePrecompiledLetterNotificationResponseJson);
 
-            LetterNotificationResponse actualResponse = client.SendPrecompiledLetter(Constants.fakeNotificationReference, Encoding.UTF8.GetBytes("%PDF-1.5 testpdf"));
+            LetterNotificationResponse actualResponse = await client.SendPrecompiledLetterAsync(Constants.fakeNotificationReference, Encoding.UTF8.GetBytes("%PDF-1.5 testpdf"));
 
             Assert.IsNotNull(expectedResponse.id);
             Assert.IsNotNull(expectedResponse.reference);
-            Assert.IsNotNull(expectedResponse.postage);
             Assert.IsNull(expectedResponse.content);
             Assert.IsTrue(expectedResponse.Equals(actualResponse));
 
@@ -657,8 +634,8 @@ namespace Notify.Tests.UnitTests
                 }));
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendEmailNotificationWithReplyToIdGeneratesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendEmailNotificationWithReplyToIdGeneratesExpectedRequest()
         {
             var personalisation = new Dictionary<string, dynamic>
             {
@@ -681,11 +658,11 @@ namespace Notify.Tests.UnitTests
                 AssertGetExpectedContent,
                 expected.ToString(Formatting.None));
 
-            var response = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference, Constants.fakeReplyToId);
+            var response = await client.SendEmailAsync(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference, Constants.fakeReplyToId);
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendEmailNotificationWithReplyToIdGeneratesExpectedResponse()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendEmailNotificationWithReplyToIdGeneratesExpectedResponse()
         {
             var personalisation = new Dictionary<string, dynamic>
             {
@@ -696,13 +673,13 @@ namespace Notify.Tests.UnitTests
 
             MockRequest(Constants.fakeEmailNotificationResponseJson);
             
-            var actualResponse = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference, Constants.fakeReplyToId);
+            var actualResponse = await client.SendEmailAsync(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference, Constants.fakeReplyToId);
 
             Assert.IsTrue(expectedResponse.Equals(actualResponse));
         }
 
-        [Test, Category("Unit/NotificationClient")]
-        public void SendSmsNotificationWithSmsSenderIdGeneratesExpectedRequest()
+        [Test, Category("Unit/NotificationClientAsync")]
+        public async Task SendSmsNotificationWithSmsSenderIdGeneratesExpectedRequest()
         {
             var personalisation = new Dictionary<string, dynamic>
                 {
@@ -722,7 +699,7 @@ namespace Notify.Tests.UnitTests
                 HttpMethod.Post,
                 AssertGetExpectedContent, expected.ToString(Formatting.None));
 
-            var response = client.SendSms(
+            var response = await client.SendSmsAsync(
                 Constants.fakePhoneNumber, Constants.fakeTemplateId, personalisation: personalisation, smsSenderId: Constants.fakeSMSSenderId);
         }
     }

--- a/src/Notify.Tests/UnitTests/NotificationClientUnitTests.cs
+++ b/src/Notify.Tests/UnitTests/NotificationClientUnitTests.cs
@@ -1,0 +1,730 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Notify.Client;
+using Notify.Exceptions;
+using Notify.Interfaces;
+using Notify.Models;
+using Notify.Models.Responses;
+using NUnit.Framework;
+
+namespace Notify.Tests.UnitTests
+{
+    [TestFixture]
+    public class NotificationClientUnitTests
+    {
+        private Mock<HttpMessageHandler> handler;
+        private NotificationClient client;
+
+        [SetUp]
+        public void SetUp()
+        {
+            handler = new Mock<HttpMessageHandler>();
+
+            var w = new HttpClientWrapper(new HttpClient(handler.Object));
+            client = new NotificationClient(w, Constants.fakeApiKey);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            handler = null;
+            client = null;
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void CreateNotificationClientWithInvalidApiKeyFails()
+        {
+            Assert.Throws<NotifyAuthException>(() => new NotificationClient("someinvalidkey"));
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void CreateNotificationClientWithEmptyApiKeyFails()
+        {
+            Assert.Throws<NotifyAuthException>(() => new NotificationClient(""));
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetNonJsonResponseHandlesException()
+        {
+            MockRequest("non json response",
+                client.GET_ALL_NOTIFICATIONS_URL,
+                AssertValidRequest, status: HttpStatusCode.NotFound);
+
+            var ex = Assert.Throws<NotifyClientException>(() => client.GetNotifications());
+            Assert.That(ex.Message, Does.Contain("Status code 404. Error: non json response"));
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetNotificationWithIdCreatesExpectedRequest()
+        {
+            MockRequest(Constants.fakeNotificationJson,
+                client.GET_NOTIFICATION_URL + Constants.fakeNotificationId,
+                AssertValidRequest);
+
+            client.GetNotificationById(Constants.fakeNotificationId);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllNotificationsCreatesExpectedResult()
+        {
+            MockRequest(Constants.fakeNotificationsJson,
+                client.GET_ALL_NOTIFICATIONS_URL,
+                AssertValidRequest);
+
+            client.GetNotifications();
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllNotificationsWithStatusCreatesExpectedResult()
+        {
+            MockRequest(Constants.fakeNotificationsJson,
+                client.GET_ALL_NOTIFICATIONS_URL + "?status=sending",
+                AssertValidRequest);
+
+            client.GetNotifications(status: "sending");
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllNotificationsWithReferenceCreatesExpectedResult()
+        {
+            MockRequest(Constants.fakeNotificationsJson,
+                client.GET_ALL_NOTIFICATIONS_URL + "?reference=foo",
+                AssertValidRequest);
+
+            client.GetNotifications(reference: "foo");
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllSmsNotificationsWithStatusAndReferenceWithCreatesExpectedResult()
+        {
+            MockRequest(Constants.fakeNotificationsJson,
+                client.GET_ALL_NOTIFICATIONS_URL + "?template_type=sms&status=sending&reference=foo",
+                AssertValidRequest);
+
+            client.GetNotifications(templateType: "sms", status: "sending", reference: "foo");
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllSmsNotificationsCreatesExpectedResult()
+        {
+            MockRequest(Constants.fakeSmsNotificationResponseJson,
+                client.GET_ALL_NOTIFICATIONS_URL + "?template_type=sms",
+                AssertValidRequest);
+
+            client.GetNotifications(templateType: "sms");
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllEmailNotificationsCreatesExpectedResult()
+        {
+            MockRequest(Constants.fakeEmailNotificationResponseJson,
+                client.GET_ALL_NOTIFICATIONS_URL + "?template_type=email",
+                AssertValidRequest);
+
+            client.GetNotifications(templateType: "email");
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllLetterNotificationsCreatesExpectedResult()
+        {
+            MockRequest(Constants.fakeEmailNotificationResponseJson,
+                client.GET_ALL_NOTIFICATIONS_URL + "?template_type=letter",
+                AssertValidRequest);
+
+            client.GetNotifications(templateType: "letter");
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetTemplateWithIdCreatesExpectedRequest()
+        {
+            MockRequest(Constants.fakeTemplateResponseJson,
+                client.GET_TEMPLATE_URL + Constants.fakeTemplateId,
+                AssertValidRequest);
+
+            client.GetTemplateByIdAndVersion(Constants.fakeTemplateId);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetTemplateWithIdAndVersionCreatesExpectedRequest()
+        {
+            MockRequest(Constants.fakeTemplateResponseJson,
+                client.GET_TEMPLATE_URL + Constants.fakeTemplateId + client.VERSION_PARAM + "2",
+                AssertValidRequest);
+
+            client.GetTemplateByIdAndVersion(Constants.fakeTemplateId, 2);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetNotificationWithIdReceivesExpectedResponse()
+        {
+            var expectedResponse = JsonConvert.DeserializeObject<Notification>(Constants.fakeNotificationJson);
+
+            MockRequest(Constants.fakeNotificationJson);
+
+            var responseNotification = client.GetNotificationById(Constants.fakeNotificationId);
+            Assert.IsTrue(expectedResponse.Equals(responseNotification));
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetTemplateWithIdReceivesExpectedResponse()
+        {
+            var expectedResponse = JsonConvert.DeserializeObject<TemplateResponse>(Constants.fakeTemplateResponseJson);
+
+            MockRequest(Constants.fakeTemplateResponseJson);
+
+            var responseTemplate = client.GetTemplateById(Constants.fakeTemplateId);
+            Assert.IsTrue(expectedResponse.Equals(responseTemplate));
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetTemplateWithIdAndVersionReceivesExpectedResponse()
+        {
+            var expectedResponse =
+                JsonConvert.DeserializeObject<TemplateResponse>(Constants.fakeTemplateResponseJson);
+
+            MockRequest(Constants.fakeTemplateResponseJson);
+
+            var responseTemplate = client.GetTemplateByIdAndVersion(Constants.fakeTemplateId, 2);
+            Assert.IsTrue(expectedResponse.Equals(responseTemplate));
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GenerateTemplatePreviewGeneratesExpectedRequest()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic> {
+                    { "name", "someone" }
+            };
+
+            var o = new JObject
+            {
+                { "personalisation", JObject.FromObject(personalisation) }
+            };
+
+            MockRequest(Constants.fakeTemplatePreviewResponseJson,
+                client.GET_TEMPLATE_URL + Constants.fakeTemplateId + "/preview", AssertValidRequest, HttpMethod.Post);
+
+            var response = client.GenerateTemplatePreview(Constants.fakeTemplateId, personalisation);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GenerateTemplatePreviewReceivesExpectedResponse()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic> {
+                    { "name", "someone" }
+            };
+
+            var expected = new JObject
+            {
+                { "personalisation", JObject.FromObject(personalisation) }
+            };
+
+            MockRequest(Constants.fakeTemplatePreviewResponseJson,
+                client.GET_TEMPLATE_URL + Constants.fakeTemplateId + "/preview",
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            client.GenerateTemplatePreview(Constants.fakeTemplateId, personalisation);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllTemplatesCreatesExpectedRequest()
+        {
+            MockRequest(Constants.fakeTemplateListResponseJson,
+                 client.GET_ALL_TEMPLATES_URL, AssertValidRequest);
+
+            client.GetAllTemplates();
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllTemplatesBySmsTypeCreatesExpectedRequest()
+        {
+            const string type = "sms";
+            MockRequest(Constants.fakeTemplateSmsListResponseJson,
+                         client.GET_ALL_TEMPLATES_URL+ client.TYPE_PARAM + type, AssertValidRequest);
+
+            client.GetAllTemplates(type);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllTemplatesByEmailTypeCreatesExpectedRequest()
+        {
+            const string type = "email";
+
+            MockRequest(Constants.fakeTemplateEmailListResponseJson,
+                         client.GET_ALL_TEMPLATES_URL+ client.TYPE_PARAM + type, AssertValidRequest);
+
+            client.GetAllTemplates(type);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllTemplatesForEmptyListReceivesExpectedResponse()
+        {
+            var expectedResponse = JsonConvert.DeserializeObject<TemplateList>(Constants.fakeTemplateEmptyListResponseJson);
+
+               MockRequest(Constants.fakeTemplateEmptyListResponseJson);
+
+            TemplateList templateList = client.GetAllTemplates();
+
+            List<TemplateResponse> templates = templateList.templates;
+
+            Assert.IsTrue(templates.Count == 0);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllTemplatesReceivesExpectedResponse()
+        {
+            TemplateList expectedResponse = JsonConvert.DeserializeObject<TemplateList>(Constants.fakeTemplateListResponseJson);
+
+            MockRequest(Constants.fakeTemplateListResponseJson);
+
+            TemplateList templateList = client.GetAllTemplates();
+
+            List<TemplateResponse> templates = templateList.templates;
+
+            Assert.AreEqual(templates.Count, expectedResponse.templates.Count);
+            for (int i = 0; i < templates.Count; i++)
+            {
+                Assert.IsTrue(expectedResponse.templates[i].Equals(templates[i]));
+            }
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllTemplatesBySmsTypeReceivesExpectedResponse()
+        {
+            const string type = "sms";
+
+            TemplateList expectedResponse =
+                JsonConvert.DeserializeObject<TemplateList>(Constants.fakeTemplateSmsListResponseJson);
+
+            MockRequest(Constants.fakeTemplateSmsListResponseJson,
+                         client.GET_ALL_TEMPLATES_URL + client.TYPE_PARAM + type, AssertValidRequest);
+
+            TemplateList templateList = client.GetAllTemplates(type);
+
+            List<TemplateResponse> templates = templateList.templates;
+
+            Assert.AreEqual(templates.Count, expectedResponse.templates.Count);
+            for (int i = 0; i < templates.Count; i++)
+            {
+                Assert.IsTrue(expectedResponse.templates[i].Equals(templates[i]));
+            }
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllTemplatesByEmailTypeReceivesExpectedResponse()
+        {
+            const string type = "email";
+
+            TemplateList expectedResponse =
+                JsonConvert.DeserializeObject<TemplateList>(Constants.fakeTemplateEmailListResponseJson);
+
+            MockRequest(Constants.fakeTemplateEmailListResponseJson,
+                         client.GET_ALL_TEMPLATES_URL + client.TYPE_PARAM + type, AssertValidRequest);
+
+            TemplateList templateList = client.GetAllTemplates(type);
+
+            List<TemplateResponse> templates = templateList.templates;
+
+            Assert.AreEqual(templates.Count, expectedResponse.templates.Count);
+            for (int i = 0; i < templates.Count; i++)
+            {
+                Assert.IsTrue(expectedResponse.templates[i].Equals(templates[i]));
+            }
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllReceivedTextsCreatesExpectedRequest()
+        {
+            MockRequest(Constants.fakeReceivedTextListResponseJson,
+                 client.GET_RECEIVED_TEXTS_URL, AssertValidRequest);
+
+            client.GetReceivedTexts();
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void GetAllReceivedTextsReceivesExpectedResponse()
+        {
+            MockRequest(Constants.fakeReceivedTextListResponseJson,
+                 client.GET_RECEIVED_TEXTS_URL, AssertValidRequest);
+
+            ReceivedTextListResponse expectedResponse =
+                JsonConvert.DeserializeObject<ReceivedTextListResponse>(Constants.fakeReceivedTextListResponseJson);
+
+            MockRequest(Constants.fakeReceivedTextListResponseJson,
+                         client.GET_RECEIVED_TEXTS_URL, AssertValidRequest);
+
+            ReceivedTextListResponse receivedTextList = client.GetReceivedTexts();
+
+            List<ReceivedTextResponse> receivedTexts = receivedTextList.receivedTexts;
+
+            Assert.AreEqual(receivedTexts.Count, expectedResponse.receivedTexts.Count);
+            for (int i = 0; i < receivedTexts.Count; i++)
+            {
+                Assert.IsTrue(expectedResponse.receivedTexts[i].Equals(receivedTexts[i]));
+            }
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendSmsNotificationGeneratesExpectedRequest()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
+                {
+                    { "name", "someone" }
+                };
+            JObject expected = new JObject
+            {
+                { "phone_number", Constants.fakePhoneNumber },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", JObject.FromObject(personalisation) }
+            };
+
+            MockRequest(Constants.fakeSmsNotificationResponseJson,
+                client.SEND_SMS_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            SmsNotificationResponse response = client.SendSms(Constants.fakePhoneNumber, Constants.fakeTemplateId, personalisation);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendSmsNotificationGeneratesExpectedResponse()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
+                {
+                    { "name", "someone" }
+                };
+            SmsNotificationResponse expectedResponse = JsonConvert.DeserializeObject<SmsNotificationResponse>(Constants.fakeSmsNotificationResponseJson);
+
+            MockRequest(Constants.fakeSmsNotificationResponseJson);
+
+            SmsNotificationResponse actualResponse = client.SendSms(Constants.fakePhoneNumber, Constants.fakeTemplateId, personalisation);
+
+            Assert.IsTrue(expectedResponse.Equals(actualResponse));
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendEmailNotificationGeneratesExpectedRequest()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
+                {
+                    { "name", "someone" }
+                };
+            JObject expected = new JObject
+            {
+                { "email_address", Constants.fakeEmail },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", JObject.FromObject(personalisation) },
+                { "reference", Constants.fakeNotificationReference }
+            };
+
+            MockRequest(Constants.fakeTemplatePreviewResponseJson,
+                client.SEND_EMAIL_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            EmailNotificationResponse response = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendEmailNotificationWithDocumentGeneratesExpectedRequest()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
+                {
+                    { "document", NotificationClient.PrepareUpload(Encoding.UTF8.GetBytes("%PDF-1.5 testpdf")) }
+                };
+            JObject expected = new JObject
+            {
+                { "email_address", Constants.fakeEmail },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", new JObject
+                  {
+                    {"document", new JObject
+                      {
+                        {"file", "JVBERi0xLjUgdGVzdHBkZg=="}
+                      }
+                    }
+                  }
+                },
+                { "reference", Constants.fakeNotificationReference }
+            };
+
+            MockRequest(Constants.fakeTemplatePreviewResponseJson,
+                client.SEND_EMAIL_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            EmailNotificationResponse response = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void PrepareUploadWithLargeDocumentGeneratesAnError()
+        {
+            Assert.That(
+                    () => { NotificationClient.PrepareUpload(new byte[3*1024*1024]); },
+                    Throws.ArgumentException
+                    );
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendEmailNotificationGeneratesExpectedResponse()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
+                {
+                    { "name", "someone" }
+                };
+            EmailNotificationResponse expectedResponse = JsonConvert.DeserializeObject<EmailNotificationResponse>(Constants.fakeEmailNotificationResponseJson);
+
+            MockRequest(Constants.fakeEmailNotificationResponseJson);
+
+            EmailNotificationResponse actualResponse = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+
+            Assert.IsTrue(expectedResponse.Equals(actualResponse));
+
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendLetterNotificationGeneratesExpectedRequest()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
+                {
+                    { "address_line_1", "Foo" },
+                    { "address_line_2", "Bar" },
+                    { "postcode", "Baz" }
+                };
+            JObject expected = new JObject
+            {
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", JObject.FromObject(personalisation) },
+                { "reference", Constants.fakeNotificationReference }
+            };
+
+            MockRequest(Constants.fakeTemplatePreviewResponseJson,
+                client.SEND_LETTER_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            LetterNotificationResponse response = client.SendLetter(Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendLetterNotificationGeneratesExpectedResponse()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
+                {
+                    { "address_line_1", "Foo" },
+                    { "address_line_2", "Bar" },
+                    { "postcode", "Baz" }
+                };
+            LetterNotificationResponse expectedResponse = JsonConvert.DeserializeObject<LetterNotificationResponse>(Constants.fakeLetterNotificationResponseJson);
+
+            MockRequest(Constants.fakeLetterNotificationResponseJson);
+
+            LetterNotificationResponse actualResponse = client.SendLetter(Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+
+            Assert.IsTrue(expectedResponse.Equals(actualResponse));
+
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendPrecompiledLetterNotificationGeneratesExpectedRequest()
+        {
+            JObject expected = new JObject
+            {
+                { "reference", Constants.fakeNotificationReference },
+                { "content", "JVBERi0xLjUgdGVzdHBkZg==" }
+            };
+
+            MockRequest(Constants.fakeTemplatePreviewResponseJson,
+                client.SEND_LETTER_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            LetterNotificationResponse response = client.SendPrecompiledLetter(
+                    Constants.fakeNotificationReference,
+                    Encoding.UTF8.GetBytes("%PDF-1.5 testpdf")
+            );
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendPrecompiledLetterNotificationGeneratesExpectedRequestWithPostage()
+        {
+            JObject expected = new JObject
+            {
+                { "reference", Constants.fakeNotificationReference },
+                { "content", "JVBERi0xLjUgdGVzdHBkZg==" },
+                { "postage", "first" }
+            };
+
+            MockRequest(Constants.fakeTemplatePreviewResponseJson,
+                client.SEND_LETTER_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            LetterNotificationResponse response = client.SendPrecompiledLetter(
+                    Constants.fakeNotificationReference,
+                    Encoding.UTF8.GetBytes("%PDF-1.5 testpdf"),
+                    "first"
+            );
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendPrecompiledLetterNotificationGeneratesExpectedResponse()
+        {
+            LetterNotificationResponse expectedResponse = JsonConvert.DeserializeObject<LetterNotificationResponse>(Constants.fakePrecompiledLetterNotificationResponseJson);
+
+            MockRequest(Constants.fakePrecompiledLetterNotificationResponseJson);
+
+            LetterNotificationResponse actualResponse = client.SendPrecompiledLetter(Constants.fakeNotificationReference, Encoding.UTF8.GetBytes("%PDF-1.5 testpdf"));
+
+            Assert.IsNotNull(expectedResponse.id);
+            Assert.IsNotNull(expectedResponse.reference);
+            Assert.IsNotNull(expectedResponse.postage);
+            Assert.IsNull(expectedResponse.content);
+            Assert.IsTrue(expectedResponse.Equals(actualResponse));
+
+        }
+
+        private static void AssertGetExpectedContent(string expected, string content)
+        {
+            Assert.IsNotNull(content);
+            Assert.AreEqual(expected, content);
+        }
+
+        private void AssertValidRequest(string uri, HttpRequestMessage r, HttpMethod method = null)
+        {
+            if (method == null)
+            {
+                method = HttpMethod.Get;
+            }
+                
+            Assert.AreEqual(r.Method, method);
+            Assert.AreEqual(r.RequestUri.ToString(), client.BaseUrl + uri);
+            Assert.IsNotNull(r.Headers.Authorization);
+            Assert.IsNotNull(r.Headers.UserAgent);
+            Assert.AreEqual(r.Headers.UserAgent.ToString(), client.GetUserAgent());
+            Assert.AreEqual(r.Headers.Accept.ToString(), "application/json");
+        }
+
+        private void MockRequest(string content, string uri,
+                          Action<string, HttpRequestMessage, HttpMethod> _assertValidRequest = null,
+                          HttpMethod method = null,
+                          Action<string, string> _assertGetExpectedContent = null, 
+                          string expected = null,
+                          HttpStatusCode status = HttpStatusCode.OK)
+        {
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns(Task<HttpResponseMessage>.Factory.StartNew(() => new HttpResponseMessage
+                {
+                    StatusCode = status,
+                    Content = new StringContent(content)
+                }))
+                .Callback<HttpRequestMessage, CancellationToken>((r, c) =>
+                {
+                    _assertValidRequest(uri, r, method);
+
+                    if (r.Content == null || _assertGetExpectedContent == null) return;
+
+                    var response = r.Content.ReadAsStringAsync().Result;
+                    _assertGetExpectedContent(expected, response);
+                });
+        }
+
+        private void MockRequest(string content)
+        {
+
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns(Task<HttpResponseMessage>.Factory.StartNew(() => new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(content)
+                }));
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendEmailNotificationWithReplyToIdGeneratesExpectedRequest()
+        {
+            var personalisation = new Dictionary<string, dynamic>
+            {
+                { "name", "someone" }
+            };
+
+            var expected = new JObject
+            {
+                { "email_address", Constants.fakeEmail },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", JObject.FromObject(personalisation) },
+                { "reference", Constants.fakeNotificationReference },
+                { "email_reply_to_id", Constants.fakeReplyToId}
+            };
+
+            MockRequest(Constants.fakeTemplateEmailListResponseJson,
+                client.SEND_EMAIL_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent,
+                expected.ToString(Formatting.None));
+
+            var response = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference, Constants.fakeReplyToId);
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendEmailNotificationWithReplyToIdGeneratesExpectedResponse()
+        {
+            var personalisation = new Dictionary<string, dynamic>
+            {
+                { "name", "someone" }
+            };
+
+            var expectedResponse = JsonConvert.DeserializeObject<EmailNotificationResponse>(Constants.fakeEmailNotificationResponseJson);
+
+            MockRequest(Constants.fakeEmailNotificationResponseJson);
+            
+            var actualResponse = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference, Constants.fakeReplyToId);
+
+            Assert.IsTrue(expectedResponse.Equals(actualResponse));
+        }
+
+        [Test, Category("Unit/NotificationClient")]
+        public void SendSmsNotificationWithSmsSenderIdGeneratesExpectedRequest()
+        {
+            var personalisation = new Dictionary<string, dynamic>
+                {
+                    { "name", "someone" }
+                };
+            var expected = new JObject
+            {
+                { "phone_number", Constants.fakePhoneNumber },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", JObject.FromObject(personalisation) },
+                { "sms_sender_id", Constants.fakeSMSSenderId }
+            };
+
+            MockRequest(Constants.fakeSmsNotificationWithSMSSenderIdResponseJson,
+                client.SEND_SMS_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            var response = client.SendSms(
+                Constants.fakePhoneNumber, Constants.fakeTemplateId, personalisation: personalisation, smsSenderId: Constants.fakeSMSSenderId);
+        }
+    }
+}

--- a/src/Notify/Client/BaseClient.cs
+++ b/src/Notify/Client/BaseClient.cs
@@ -7,6 +7,7 @@ using System;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Notify.Client
 {
@@ -37,18 +38,18 @@ namespace Notify.Client
             this.client.AddUserAgent(NOTIFY_CLIENT_NAME + productVersion);
         }
 
-        public string GET(string url)
+        public async Task<string> GET(string url)
         {
-            return MakeRequest(url, HttpMethod.Get);
+            return await MakeRequest(url, HttpMethod.Get);
         }
 
-        public string POST(string url, string json)
+        public async Task<string> POST(string url, string json)
         {
             var content = new StringContent(json, Encoding.UTF8, "application/json");
-            return MakeRequest(url, HttpMethod.Post, content);
+            return await MakeRequest(url, HttpMethod.Post, content);
         }
 
-        public string MakeRequest(string url, HttpMethod method, HttpContent content = null)
+        public async Task<string> MakeRequest(string url, HttpMethod method, HttpContent content = null)
         {
             var request = new HttpRequestMessage(method, url);
 
@@ -64,7 +65,7 @@ namespace Notify.Client
 
             try
             {
-                response = this.client.SendAsync(request);
+                response = await this.client.SendAsync(request);
             }
             catch (AggregateException ae)
             {
@@ -79,7 +80,7 @@ namespace Notify.Client
                 throw ae.Flatten();
             }
 
-            var responseContent = response.Content.ReadAsStringAsync().Result;
+            var responseContent = await response.Content.ReadAsStringAsync();
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/Notify/Client/HttpClientWrapper.cs
+++ b/src/Notify/Client/HttpClientWrapper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 
 namespace Notify.Client
 {
@@ -30,9 +31,9 @@ namespace Notify.Client
             _client.Dispose();
         }
 
-        public HttpResponseMessage SendAsync(HttpRequestMessage request)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
         {
-            return _client.SendAsync(request).Result;
+            return await _client.SendAsync(request);
         }
 
         public void SetClientBaseAddress()

--- a/src/Notify/Interfaces/IAsyncNotificationClient.cs
+++ b/src/Notify/Interfaces/IAsyncNotificationClient.cs
@@ -1,0 +1,32 @@
+﻿using Notify.Models;
+using Notify.Models.Responses;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Notify.Interfaces
+{
+    public interface IAsyncNotificationClient : IBaseClient
+    {
+        Task<TemplatePreviewResponse> GenerateTemplatePreviewAsync(string templateId, Dictionary<string, dynamic> personalisation = null);
+
+        Task<TemplateList> GetAllTemplatesAsync(string templateType = "");
+
+        Task<Notification> GetNotificationByIdAsync(string notificationId);
+
+        Task<NotificationList> GetNotificationsAsync(string templateType = "", string status = "", string reference = "", string olderThanId = "");
+
+        Task<ReceivedTextListResponse> GetReceivedTextsAsync(string olderThanId = "");
+
+        Task<TemplateResponse> GetTemplateByIdAsync(string templateId);
+
+        Task<TemplateResponse> GetTemplateByIdAndVersionAsync(string templateId, int version = 0);
+
+        Task<SmsNotificationResponse> SendSmsAsync(string mobileNumber, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string smsSenderId = null);
+
+        Task<EmailNotificationResponse> SendEmailAsync(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string emailReplyToId = null);
+
+        Task<LetterNotificationResponse> SendLetterAsync(string templateId, Dictionary<string, dynamic> personalisation, string clientReference = null);
+
+        Task<LetterNotificationResponse> SendPrecompiledLetterAsync(string clientReference, byte[] pdfContents, string postage);
+    }
+}

--- a/src/Notify/Interfaces/IBaseClient.cs
+++ b/src/Notify/Interfaces/IBaseClient.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Notify.Interfaces
 {
     public interface IBaseClient
     {
-        string GET(string url);
+        Task<string> GET(string url);
 
-        string POST(string url, string json);
+        Task<string> POST(string url, string json);
 
-        string MakeRequest(string url, HttpMethod method, HttpContent content = null);
+        Task<string> MakeRequest(string url, HttpMethod method, HttpContent content = null);
 
         Tuple<string, string> ExtractServiceIdAndApiKey(string fromApiKey);
 

--- a/src/Notify/Interfaces/IHttpClient.cs
+++ b/src/Notify/Interfaces/IHttpClient.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Notify.Interfaces
 {
     public interface IHttpClient : IDisposable
     {
-        HttpResponseMessage SendAsync(HttpRequestMessage request);
+        Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
 
         Uri BaseAddress { get; set; }
 

--- a/src/Notify/Interfaces/INotificationClient.cs
+++ b/src/Notify/Interfaces/INotificationClient.cs
@@ -6,12 +6,26 @@ namespace Notify.Interfaces
 {
     public interface INotificationClient : IBaseClient
     {
+        TemplatePreviewResponse GenerateTemplatePreview(string templateId, Dictionary<string, dynamic> personalisation = null);
+
+        TemplateList GetAllTemplates(string templateType = "");
+
         Notification GetNotificationById(string notificationId);
 
         NotificationList GetNotifications(string templateType = "", string status = "", string reference = "", string olderThanId = "");
 
+        ReceivedTextListResponse GetReceivedTexts(string olderThanId = "");
+
+        TemplateResponse GetTemplateById(string templateId);
+
+        TemplateResponse GetTemplateByIdAndVersion(string templateId, int version = 0);
+
         SmsNotificationResponse SendSms(string mobileNumber, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string smsSenderId = null);
 
         EmailNotificationResponse SendEmail(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string emailReplyToId = null);
+
+        LetterNotificationResponse SendLetter(string templateId, Dictionary<string, dynamic> personalisation, string clientReference = null);
+
+        LetterNotificationResponse SendPrecompiledLetter(string clientReference, byte[] pdfContents, string postage = null);
     }
 }

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
## What problem does the pull request solve?

The current implementation of the API Client is synchronous.  This was causing bottlenecks during our load testing (which sends lots of messages using Notify).  We modified the code to make the API Client methods asynchronous as part of measures to improve the performance of our system.  We would like to share these changes with you, as they may be useful for other projects.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (in `src/Notify/Notify.csproj`)

I have updated CHANGELOG.md but not DOCUMENTATION.md.  Should I duplicate all the descriptions of the synchronous methods to describe their asynchronous counterparts?  Or is it better to add a footnote to say that asynchronous versions of the methods are available?