### PR TITLE
Adding missing interface definitions for templating methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.4.1] - 2019-03-12
+
+* Added GetAllTemplates, GenerateTemplatePreview, GetTemplateById and GetTemplateByIdAndVersion to the INoficiationClient interface.
+
 ## [2.4.0] - 2018-02-11
 
 * Add an optional `postage` argument to `SendPrecompiledLetter`.

--- a/src/Notify/Interfaces/INotificationClient.cs
+++ b/src/Notify/Interfaces/INotificationClient.cs
@@ -13,5 +13,13 @@ namespace Notify.Interfaces
         SmsNotificationResponse SendSms(string mobileNumber, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string smsSenderId = null);
 
         EmailNotificationResponse SendEmail(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string emailReplyToId = null);
+
+        TemplateList GetAllTemplates(string templateType = "");
+
+        TemplatePreviewResponse GenerateTemplatePreview(string templateId, Dictionary<string, dynamic> personalisation = null);
+        
+        TemplateResponse GetTemplateById(string templateId);
+
+        TemplateResponse GetTemplateByIdAndVersion(string templateId, int version = 0);
     }
 }

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
## What problem does the pull request solve?

Injecting an INotificationClient into my IOC container doesn't allow me to access template methods. I'm currently having to wrap the client in my own proxy class to be able to make my code testable.

## Checklist

- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes *no coverage required*
- [x] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (in `src/Notify/Notify.csproj`)