### PR TITLE
Correct the documentation describing the responses.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -447,11 +447,10 @@ public class Template
     public String uri;
     public Int32 version;
 }
-public class LetterResponseContent
-{
+public class LetterResponseContent{
     public string body;
     public string subject;
-
+}
 ```
 
 ### Error codes
@@ -504,27 +503,15 @@ You can choose first or second class postage for your precompiled letter. Set th
 
 ### Response
 
-If the request to the client is successful, the client returns a `LetterNotificationResponse` with the `id`, `reference` and `postage` sets the other attributes are null:
+If the request to the client is successful, the client returns a `LetterNotificationResponse` with the `id`, `reference` and `postage`:
 
 ```csharp
 public String id;
 public String reference;
 public String postage;
-public String uri;
-public Template template;
-public LetterResponseContent content;
-
-public class Template
-{
-    public String id;
-    public String uri;
-    public Int32 version;
-}
-
-public class LetterResponseContent
-{
-    public string body;
-    public string subject;
+public String uri;  // null for this response
+public Template template;  // null for this response
+public LetterResponseContent content;  // null for this response
 
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -146,17 +146,20 @@ You can leave out this argument if your service only has one text message sender
 If the request to the client is successful, the client returns an `SmsNotificationResponse`:
 
 ```csharp
-public String fromNumber;
-public String body;
 public String id;
 public String reference;
 public String uri;
 public Template template;
+public SmsResponseContent;
 
 public class Template {
     public String id;
     public String uri;
     public Int32 version;
+}
+public class SmsResponseContent{
+    public string body;
+    public string fromNumber;
 }
 
 ```
@@ -260,19 +263,21 @@ You can leave out this argument if your service only has one email reply-to addr
 If the request to the client is successful, the client returns an `EmailNotificationResponse`:
 
 ```csharp
-public String fromEmail;
-public String body;
-public String subject;
 public String id;
 public String reference;
 public String uri;
 public Template template;
+public EmailResponseContent content;
 
-public class Template
-{
+public class Template{
     public String id;
     public String uri;
     public Int32 version;
+}
+public class EmailResponseContent{
+  public String fromEmail;
+  public String body;
+  public String subject;
 }
 ```
 
@@ -430,11 +435,11 @@ If the request to the client is successful, the client returns a `LetterNotifica
 
 ```csharp
 public String id;
-public String body;
-public String subject;
 public String reference;
 public String uri;
 public Template template;
+public string postage;
+public LetterResponseContent content;
 
 public class Template
 {
@@ -442,6 +447,11 @@ public class Template
     public String uri;
     public Int32 version;
 }
+public class LetterResponseContent
+{
+    public string body;
+    public string subject;
+
 ```
 
 ### Error codes
@@ -494,12 +504,28 @@ You can choose first or second class postage for your precompiled letter. Set th
 
 ### Response
 
-If the request to the client is successful, the client returns a `LetterNotificationResponse` with the `id`, `reference` and `postage` set:
+If the request to the client is successful, the client returns a `LetterNotificationResponse` with the `id`, `reference` and `postage` sets the other attributes are null:
 
 ```csharp
 public String id;
 public String reference;
 public String postage;
+public String uri;
+public Template template;
+public LetterResponseContent content;
+
+public class Template
+{
+    public String id;
+    public String uri;
+    public Int32 version;
+}
+
+public class LetterResponseContent
+{
+    public string body;
+    public string subject;
+
 ```
 
 ### Error codes
@@ -608,6 +634,16 @@ public String sentAt;
 public String status;
 public Template template;
 public String type;
+public string createdByName;
+
+public class Template
+{
+    public String id;
+    public String uri;
+    public Int32 version;
+}
+
+
 ```
 
 ### Error codes


### PR DESCRIPTION
The documentation needed an update for the responses. 
