### PR TITLE
Remove API recommendation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,8 +2,6 @@
 
 This documentation is for developers interested in using the GOV.UK Notify .NET client to send emails (including documents), text messages or letters. GOV.UK Notify supports .NET framework 4.6.2 and .NET Core 2.0.
 
-We recommend that you use this client library rather than use the [GOV.UK Notify API](https://github.com/alphagov/notifications-api) directly, as there is no documentation for using the API in this way.
-
 # Set up the client
 
 ## Prerequisites


### PR DESCRIPTION
## What problem does the pull request solve?
We're adding the following content to [https://www.notifications.service.gov.uk/documentation](https://www.notifications.service.gov.uk/documentation):

>## Integrating directly with the API
>We recommend using the client libraries rather than integrating directly with the API.
>There’s no documentation for using the API in this way. You’ll still need to read the client documentation to understand:
>* what the API client does
>* what development work you’ll need to do
>To send a message you’ll need to create an HTTPS request and add an authorisation header with your API key. The API key is encoded with JSON Web Tokens (JWT).

It seems unnecessary to repeat the recommendation in each of the client docs.