### PR TITLE
Explain how document encryption links are special

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -322,6 +322,8 @@ This is an invitation-only feature. [Contact the GOV.UK Notify team](https://www
 
 To send a file by email, add a placeholder field to the template and then upload a file. The placeholder field will contain a secure link to download the file.
 
+The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file without your permission.
+
 ### Add a placeholder field to the template
 
 1. Sign in to [GOV.UK Notify](https://www.notifications.service.gov.uk/).

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -322,7 +322,7 @@ This is an invitation-only feature. [Contact the GOV.UK Notify team](https://www
 
 To send a file by email, add a placeholder field to the template and then upload a file. The placeholder field will contain a secure link to download the file.
 
-The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file without your permission.
+The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
 
 ### Add a placeholder field to the template
 


### PR DESCRIPTION
Adds the following line to _Send a file by email_:

>The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.

Story: https://www.pivotaltracker.com/story/show/159524699