### PR TITLE
Fix synchronous API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.5.2] - 2019-11-18
+
+* Applied fix for issue with synchronous version of NotificationClient API
+
 ## [2.5.1] - 2019-04-26
 
 * Update JWT version to the latest

--- a/src/Notify/Client/BaseClient.cs
+++ b/src/Notify/Client/BaseClient.cs
@@ -40,13 +40,13 @@ namespace Notify.Client
 
         public async Task<string> GET(string url)
         {
-            return await MakeRequest(url, HttpMethod.Get);
+            return await MakeRequest(url, HttpMethod.Get).ConfigureAwait(false);
         }
 
         public async Task<string> POST(string url, string json)
         {
             var content = new StringContent(json, Encoding.UTF8, "application/json");
-            return await MakeRequest(url, HttpMethod.Post, content);
+            return await MakeRequest(url, HttpMethod.Post, content).ConfigureAwait(false);
         }
 
         public async Task<string> MakeRequest(string url, HttpMethod method, HttpContent content = null)
@@ -65,7 +65,7 @@ namespace Notify.Client
 
             try
             {
-                response = await this.client.SendAsync(request);
+                response = await this.client.SendAsync(request).ConfigureAwait(false);
             }
             catch (AggregateException ae)
             {
@@ -80,7 +80,7 @@ namespace Notify.Client
                 throw ae.Flatten();
             }
 
-            var responseContent = await response.Content.ReadAsStringAsync();
+            var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/Notify/Client/HttpClientWrapper.cs
+++ b/src/Notify/Client/HttpClientWrapper.cs
@@ -33,7 +33,7 @@ namespace Notify.Client
 
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
         {
-            return await _client.SendAsync(request);
+            return await _client.SendAsync(request).ConfigureAwait(false);
         }
 
         public void SetClientBaseAddress()

--- a/src/Notify/Client/NotificationClient.cs
+++ b/src/Notify/Client/NotificationClient.cs
@@ -45,7 +45,7 @@ namespace Notify.Client
         {
             var url = GET_NOTIFICATION_URL + notificationId;
 
-            var response = await this.GET(url);
+            var response = await this.GET(url).ConfigureAwait(false);
 
             try
             {
@@ -95,7 +95,7 @@ namespace Notify.Client
             }
 
             var finalUrl = GET_ALL_NOTIFICATIONS_URL + ToQueryString(query);
-            var response = await GET(finalUrl);
+            var response = await GET(finalUrl).ConfigureAwait(false);
 
             var notifications = JsonConvert.DeserializeObject<NotificationList>(response);
             return notifications;
@@ -109,7 +109,7 @@ namespace Notify.Client
                 templateType == string.Empty ? string.Empty : TYPE_PARAM + templateType
             );
 
-            var response = await GET(finalUrl);
+            var response = await GET(finalUrl).ConfigureAwait(false);
 
             var templateList = JsonConvert.DeserializeObject<TemplateList>(response);
 
@@ -124,7 +124,7 @@ namespace Notify.Client
                 string.IsNullOrWhiteSpace(olderThanId) ? "" : "?older_than=" + olderThanId
             );
 
-            var response = await this.GET(finalUrl);
+            var response = await this.GET(finalUrl).ConfigureAwait(false);
 
             var receivedTexts = JsonConvert.DeserializeObject<ReceivedTextListResponse>(response);
 
@@ -143,7 +143,7 @@ namespace Notify.Client
                 o.Add(new JProperty("sms_sender_id", smsSenderId));
             }
 
-            var response = await POST(SEND_SMS_NOTIFICATION_URL, o.ToString(Formatting.None));
+            var response = await POST(SEND_SMS_NOTIFICATION_URL, o.ToString(Formatting.None)).ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<SmsNotificationResponse>(response);            
         }
@@ -160,7 +160,7 @@ namespace Notify.Client
                 o.Add(new JProperty("email_reply_to_id", emailReplyToId));
             }
 
-            var response = await POST(SEND_EMAIL_NOTIFICATION_URL, o.ToString(Formatting.None));
+            var response = await POST(SEND_EMAIL_NOTIFICATION_URL, o.ToString(Formatting.None)).ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<EmailNotificationResponse>(response);
         }
@@ -170,7 +170,7 @@ namespace Notify.Client
         {
             var o = CreateRequestParams(templateId, personalisation, clientReference);
 
-            var response = await this.POST(SEND_LETTER_NOTIFICATION_URL, o.ToString(Formatting.None));
+            var response = await this.POST(SEND_LETTER_NOTIFICATION_URL, o.ToString(Formatting.None)).ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<LetterNotificationResponse>(response);            
         }
@@ -188,7 +188,7 @@ namespace Notify.Client
                 requestParams.Add(new JProperty("postage", postage));
             }
 
-            var response = await this.POST(SEND_LETTER_NOTIFICATION_URL, requestParams.ToString(Formatting.None));
+            var response = await this.POST(SEND_LETTER_NOTIFICATION_URL, requestParams.ToString(Formatting.None)).ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<LetterNotificationResponse>(response);
         }
@@ -197,7 +197,7 @@ namespace Notify.Client
         {
             var url = GET_TEMPLATE_URL + templateId;
 
-            return await GetTemplateFromURLAsync(url);
+            return await GetTemplateFromURLAsync(url).ConfigureAwait(false);
         }
 
         public async Task<TemplateResponse> GetTemplateByIdAndVersionAsync(string templateId, int version = 0)
@@ -205,7 +205,7 @@ namespace Notify.Client
             var pattern = "{0}{1}" + (version > 0 ? VERSION_PARAM + "{2}" : "");
             var url = string.Format(pattern, GET_TEMPLATE_URL, templateId, version);
 
-            return await GetTemplateFromURLAsync(url);
+            return await GetTemplateFromURLAsync(url).ConfigureAwait(false);
         }
 
         public async Task<TemplatePreviewResponse> GenerateTemplatePreviewAsync(string templateId,
@@ -218,7 +218,7 @@ namespace Notify.Client
                 {"personalisation", JObject.FromObject(personalisation)}
             };
 
-            var response = await this.POST(url, o.ToString(Formatting.None));
+            var response = await this.POST(url, o.ToString(Formatting.None)).ConfigureAwait(false);
 
             try
             {
@@ -244,7 +244,7 @@ namespace Notify.Client
 
         private async Task<TemplateResponse> GetTemplateFromURLAsync(string url)
         {
-            var response = await this.GET(url);
+            var response = await this.GET(url).ConfigureAwait(false);
 
             try
             {

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>2.5.1</Version>
+    <Version>2.5.2</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Earlier this year, I submitted Pull Request https://github.com/alphagov/notifications-net-client/pull/83 to add an asynchronous version of the NotificationClient API.  Subsequently, an issue was found with the synchronous version of the API whereby the affected code appears to "hang" when the API is called.  The issue occurs in specific scenarios, and most commonly affects the following project types:

- ASP.NET (Framework) websites
- .NET (Framework) Windows Forms applications

The issue is less likely to affect .NET (Framework) Console applications or .NET Core projects.  It is caused because the methods of the synchronous API are now implemented by calling the corresponding asynchronous API methods and waiting for the result.  This can lead to a deadlock on the main thread used by Windows Forms and ASP.NET applications.  The issue and work-around are described at https://medium.com/bynder-tech/c-why-you-should-use-configureawait-false-in-your-library-code-d7837dce3d7f.

I have tested the fix successfully with the following types of project:

- .NET (Framework) Console application
- .NET (Framework) Windows Forms application
- ASP.NET (Framework) website
- .NET (Core) Console application
- ASP.NET (Core) website

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (in `src/Notify/Notify.csproj`)
