### PR TITLE
Update status descriptions to help users understand the 72 hour period (.net)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -584,9 +584,9 @@ You can only get the status of messages that are 7 days old or newer.
 |Status|Information|
 |:---|:---|
 |Created|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|Sending|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient. GOV.UK Notify is waiting for delivery information.|
+|Sending|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
 |Delivered|The message was successfully delivered.|
-|Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message because the email address or phone number was wrong. You should remove these email addresses or phone numbers from your database. You’ll still be charged for text messages to numbers that do not exist."<br>- `temporary-failure` - "The provider could not deliver the message after trying for 72 hours. This can happen when the recipient's inbox is full or their phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure."|
+|Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message because the email address or phone number was wrong. You should remove these email addresses or phone numbers from your database. You’ll still be charged for text messages to numbers that do not exist."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s inbox is full or their phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure."|
 
 ## Status - text only
 
@@ -707,13 +707,13 @@ You can filter by:
 | status | description | text | email | letter |Precompiled letter|
 |:--- |:--- |:--- |:--- |:--- |:--- |
 |created|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|Yes|Yes|||
-|sending|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient. GOV.UK Notify is waiting for delivery information.|Yes|Yes|||
+|sending|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|Yes|Yes|||
 |delivered|The message was successfully delivered|Yes|Yes|||
 |sent / sent internationally|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information.|Yes||||
 |pending|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient's device has not yet responded. Another callback from the provider determines the final status of the notification.|Yes||||
 |failed|This returns all failure statuses:<br>- permanent-failure<br>- temporary-failure<br>- technical-failure|Yes|Yes|||
 |permanent-failure|The provider could not deliver the message because the email address or phone number was wrong. You should remove these email addresses or phone numbers from your database. You’ll still be charged for text messages to numbers that do not exist.|Yes|Yes|||
-|temporary-failure|The provider could not deliver the message after trying for 72 hours. This can happen when the recipient's inbox is full or their phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|Yes|Yes|||
+|temporary-failure|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|Yes|Yes|||
 |technical-failure|Email / Text: Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure. <br><br>Letter: Notify had an unexpected error while sending to our printing provider. <br><br>You can leave out this argument to ignore this filter.|Yes|Yes|||
 |accepted|GOV.UK Notify has sent the letter to the provider to be printed.|||Yes||
 |received|The provider has printed and dispatched the letter.|||Yes||


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->
This PR changes the wording of 2 message status descriptions:

- mentioning the 72 hour period in the _Sending_ status makes it explicit that this a message that remains in this state for longer than a users expects is not 'stuck'
- not mentioning the 72 hour period in the _Phone not accepting messages right now_ status should reduce any confusion for users who see this status after <72 hours

This change was prompted by feedback from a user on x-gov Slack:

>We sent out a message last night and there were a few numbers that did not get it, on checking one, it gives the message: _"The provider could not deliver the message after trying for 72 hours. This can happen when the recipient’s phone is off..."_ Given it is not even 24 hours after the text was sent, any ideas why this report is worded like this?

**New content**

>**Sending**
>Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. Notify is waiting for delivery information.

>**Failed: temporary-failure**
>The provider could not deliver the message. This can happen when the recipient’s inbox is full or their phone is off...

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/Notify/Notify.csproj`)
