### PR TITLE
Allow CSV files sent by email and doc download to download as .CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.8.0] - 2020-06-01
+
+* Add support for an optional `isCsv` parameter in the `prepare_upload()` function. This fixes a bug when sending a CSV file by email. This ensures that the file is downloaded as a CSV rather than a TXT file.
+
 ## [2.7.1] - 2020-01-27
 
 * change error message to refer to file rather than document

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -371,6 +371,21 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 };
 ```
 
+#### CSV files
+
+Uploads for CSV files should use the `isCsv` parameter on the `prepare_upload()` function. For example:
+
+```csharp
+
+byte[] documentContents = File.ReadAllBytes("<file path>");
+
+Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+{
+    { "name", "Foo" },
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents, isCsv = true)}
+};
+```
+
 ### Error codes
 
 If the request is not successful, the client returns an `HTTPError` containing the relevant error code.

--- a/src/Notify.Tests/UnitTests/NotificationClientAsyncUnitTests.cs
+++ b/src/Notify.Tests/UnitTests/NotificationClientAsyncUnitTests.cs
@@ -476,7 +476,41 @@ namespace Notify.Tests.UnitTests
                   {
                     {"document", new JObject
                       {
-                        {"file", "JVBERi0xLjUgdGVzdHBkZg=="}
+                        {"file", "JVBERi0xLjUgdGVzdHBkZg=="},
+                        {"is_csv", false}
+                      }
+                    }
+                  }
+                },
+                { "reference", Constants.fakeNotificationReference }
+            };
+
+            MockRequest(Constants.fakeTemplatePreviewResponseJson,
+                client.SEND_EMAIL_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            EmailNotificationResponse response = await client.SendEmailAsync(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+        }
+
+        [Test, Category("Unit"), Category("Unit/NotificationClientAsync")]
+        public async Task SendEmailNotificationWithCSVDocumentGeneratesExpectedRequest()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
+                {
+                    { "document", NotificationClient.PrepareUpload(Encoding.UTF8.GetBytes("%PDF-1.5 testpdf"), true) }
+                };
+            JObject expected = new JObject
+            {
+                { "email_address", Constants.fakeEmail },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", new JObject
+                  {
+                    {"document", new JObject
+                      {
+                        {"file", "JVBERi0xLjUgdGVzdHBkZg=="},
+                        {"is_csv", true}
                       }
                     }
                   }

--- a/src/Notify.Tests/UnitTests/NotificationClientUnitTests.cs
+++ b/src/Notify.Tests/UnitTests/NotificationClientUnitTests.cs
@@ -487,7 +487,41 @@ namespace Notify.Tests.UnitTests
                   {
                     {"document", new JObject
                       {
-                        {"file", "JVBERi0xLjUgdGVzdHBkZg=="}
+                        {"file", "JVBERi0xLjUgdGVzdHBkZg=="},
+                        {"is_csv", false}
+                      }
+                    }
+                  }
+                },
+                { "reference", Constants.fakeNotificationReference }
+            };
+
+            MockRequest(Constants.fakeTemplatePreviewResponseJson,
+                client.SEND_EMAIL_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent, expected.ToString(Formatting.None));
+
+            EmailNotificationResponse response = client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, Constants.fakeNotificationReference);
+        }
+
+        [Test, Category("Unit"), Category("Unit/NotificationClient")]
+        public void SendEmailNotificationWithCSVDocumentGeneratesExpectedRequest()
+        {
+            Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
+                {
+                    { "document", NotificationClient.PrepareUpload(Encoding.UTF8.GetBytes("%PDF-1.5 testpdf"), true) }
+                };
+            JObject expected = new JObject
+            {
+                { "email_address", Constants.fakeEmail },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", new JObject
+                  {
+                    {"document", new JObject
+                      {
+                        {"file", "JVBERi0xLjUgdGVzdHBkZg=="},
+                        {"is_csv", true}
                       }
                     }
                   }

--- a/src/Notify/Client/NotificationClient.cs
+++ b/src/Notify/Client/NotificationClient.cs
@@ -245,14 +245,15 @@ namespace Notify.Client
             return response;
         }
 
-        public static JObject PrepareUpload(byte[] documentContents)
+        public static JObject PrepareUpload(byte[] documentContents, bool isCsv = false)
         {
             if (documentContents.Length > 2 * 1024 * 1024) {
                 throw new System.ArgumentException("File is larger than 2MB");
             }
             return new JObject
             {
-                {"file", System.Convert.ToBase64String(documentContents)}
+                {"file", System.Convert.ToBase64String(documentContents)},
+                {"is_csv", isCsv}
             };
         }
 

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Equivalent functionality to Equivalent functionality as https://github.com/alphagov/notifications-python-client/pull/165

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (in `src/Notify/Notify.csproj`)
