### PR TITLE
Adjust heading levels in DOCUMENTATION.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,15 +2,15 @@
 
 This documentation is for developers interested in using the GOV.UK Notify .NET client to send emails (including documents), text messages or letters. GOV.UK Notify supports .NET framework 4.6.2 and .NET Core 2.0.
 
-# Set up the client
+## Set up the client
 
-## Prerequisites
+### Prerequisites
 
 This documentation assumes you are using [Microsoft Visual Studio](https://visualstudio.microsoft.com/) [external link] with the [NuGet Package Manager](https://www.nuget.org/) [external link].
 
 Refer to the [client changelog](https://github.com/alphagov/notifications-net-client/blob/master/CHANGELOG.md) for the version number and the latest updates.
 
-## Install the client
+### Install the client
 
 The GOV.UK Notify client deploys to [Bintray](https://bintray.com/) [external link].
 
@@ -24,7 +24,7 @@ You can install the GOV.UK Notify client package using either the command line o
   </strong>
 </div>
 
-### Use the command line
+#### Use the command line
 
 Go to your project directory and run the following in the command line to install the client package:
 
@@ -33,13 +33,13 @@ nuget sources Add -Name NotifyBintray -Source https://api.bintray.com/nuget/gov-
 nuget install Notify
 ```
 
-### Use Microsoft Visual Studio
+#### Use Microsoft Visual Studio
 
 Use the [NuGet Package Manager](https://docs.microsoft.com/en-us/nuget/what-is-nuget) [external link] to install the `notifications-net-client` client package in Visual Studio.
 
 You can use either the [console](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console) [external link] or [the UI](https://docs.microsoft.com/en-us/nuget/tools/package-manager-ui) [external link].
 
-#### Console
+##### Console
 
 Run the following in the NuGet package manager console to install the client package:
 
@@ -47,13 +47,13 @@ Run the following in the NuGet package manager console to install the client pac
 nuget install Notify -Source https://api.bintray.com/nuget/gov-uk-notify/nuget
 ```
 
-#### UI
+##### UI
 
 1. Add the `https://api.bintray.com/nuget/gov-uk-notify/nuget` package source to your project.
 
 1. Use the Package Manager UI to [search for and install the client package](https://docs.microsoft.com/en-us/nuget/tools/package-manager-ui#finding-and-installing-a-package) [external link].
 
-## Create a new instance of the client
+### Create a new instance of the client
 
 Add this code to your application:
 
@@ -79,13 +79,13 @@ var httpClientWithProxy = new HttpClientWrapper(new HttpClient(...));
 var client = new NotificationClient(httpClientWithProxy, apiKey);
 ```
 
-# Send a message
+## Send a message
 
 You can use GOV.UK Notify to send text messages, emails and letters.
 
-## Send a text message
+### Send a text message
 
-### Method
+#### Method
 
 ```csharp
 SmsNotificationResponse response = client.SendSms(
@@ -94,9 +94,9 @@ SmsNotificationResponse response = client.SendSms(
   );
 ```
 
-### Arguments
+#### Arguments
 
-#### mobileNumber (required)
+##### mobileNumber (required)
 
 The phone number of the recipient of the text message. This can be a UK or international number.
 
@@ -104,7 +104,7 @@ The phone number of the recipient of the text message. This can be a UK or inter
 string mobileNumber: "+447900900123";
 ```
 
-#### templateId (required)
+##### templateId (required)
 
 To find the template ID:
 
@@ -118,7 +118,7 @@ For example:
 string templateId: "f33517ff-2a88-4f6e-b855-c550268ce08a";
 ```
 
-#### personalisation (optional)
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or reference number, you need to provide their values in a `Dictionary`. For example:
 
@@ -132,7 +132,7 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if you need to. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -141,7 +141,7 @@ string reference: "STRING";
 ```
 You can leave out this argument if you do not have a reference.
 
-#### smsSenderId (optional)
+##### smsSenderId (optional)
 
 A unique identifier of the sender of the text message notification.
 
@@ -164,7 +164,7 @@ string smsSenderId: "8e222534-7f05-4972-86e3-17c5d9f894e2";
 
 You can leave out this argument if your service only has one text message sender, or if you want to use the default sender.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `SmsNotificationResponse`:
 
@@ -191,7 +191,7 @@ If you use the [test API key](#test), all your messages come back with a `delive
 
 All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys appear on your dashboard.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `Notify.Exceptions.NotifyClientException` and an error code.
 
@@ -205,9 +205,9 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification|
 
-## Send an email
+### Send an email
 
-### Method
+#### Method
 
 ```csharp
 EmailNotificationResponse response = client.SendEmail(emailAddress, templateId, personalisation, reference, emailReplyToId);
@@ -220,9 +220,9 @@ client.SendEmail(
 );
 ```
 
-### Arguments
+#### Arguments
 
-#### emailAddress (required)
+##### emailAddress (required)
 
 The email address of the recipient. For example:
 
@@ -230,7 +230,7 @@ The email address of the recipient. For example:
 string emailAddress: "sender@something.com";
 ```
 
-#### templateId (required)
+##### templateId (required)
 
 To find the template ID:
 
@@ -244,7 +244,7 @@ For example:
 string templateId: "f33517ff-2a88-4f6e-b855-c550268ce08a";
 ```
 
-#### personalisation (optional)
+##### personalisation (optional)
 
 If a template has placeholder fields for personalised information such as name or reference number, you need to provide their values in a `Dictionary`. For example:
 
@@ -260,7 +260,7 @@ Dictionary<String, dynamic> personalisation: new Dictionary<String, dynamic>
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if you need to. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -269,7 +269,7 @@ string reference: "STRING";
 ```
 You can leave out this argument if you do not have a reference.
 
-#### emailReplyToId (optional)
+##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.
 
@@ -289,7 +289,7 @@ string emailReplyToId: "8e222534-7f05-4972-86e3-17c5d9f894e2";
 
 You can leave out this argument if your service only has one email reply-to address, or you want to use the default email address.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns an `EmailNotificationResponse`:
 
@@ -312,7 +312,7 @@ public class EmailResponseContent{
 }
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `Notify.Exceptions.NotifyClientException` and an error code.
 
@@ -328,20 +328,20 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [daily limits](#daily-limits) for the limit number|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
-## Send a file by email
+### Send a file by email
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
 
-### Add contact details to the file download page
+#### Add contact details to the file download page
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Settings__ page.
 1. In the __Email__ section, select __Manage__ on the __Send files by email__ row.
 1. Enter the contact details you want to use, and select __Save__.
 
-### Add a placeholder to the template
+#### Add a placeholder to the template
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
@@ -350,7 +350,7 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 
 "Download your file at: ((link_to_file))"
 
-### Upload your file
+#### Upload your file
 
 You can upload PDF, CSV, .odt, .txt and MS Word Document files. Your file must be smaller than 2MB. [Contact the GOV.UK Notify team](https://www.notifications.service.gov.uk/support/ask-question-give-feedback) if you need to send other file types.
 
@@ -371,7 +371,7 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 };
 ```
 
-#### CSV files
+##### CSV files
 
 Uploads for CSV files should use the `isCsv` parameter on the `prepare_upload()` function. For example:
 
@@ -386,7 +386,7 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 };
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `HTTPError` containing the relevant error code.
 
@@ -404,7 +404,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 |`N/A`|`File is larger than 2MB`|The file is too big. Files must be smaller than 2MB|
 
-## Send a letter
+### Send a letter
 
 When you add a new service it will start in [trial mode](https://www.notifications.service.gov.uk/features/trial-mode). You can only send letters when your service is live.
 
@@ -414,7 +414,7 @@ To send Notify a request to go live:
 1. Go to the __Settings__ page.
 1. In the __Your service is in trial mode__ section, select __request to go live__.
 
-### Method
+#### Method
 
 ```csharp
 Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
@@ -428,9 +428,9 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 LetterNotificationResponse response = client.SendLetter(templateId, personalisation, reference);
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 To find the template ID:
 
@@ -444,7 +444,7 @@ For example:
 string templateId: "f33517ff-2a88-4f6e-b855-c550268ce08a";
 ```
 
-#### personalisation (required)
+##### personalisation (required)
 
 The personalisation argument always contains the following parameters for the letter recipient’s address:
 
@@ -478,7 +478,7 @@ personalisation: {
 }
 ```
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if you need to. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -487,7 +487,7 @@ string reference: "STRING";
 ```
 You can leave out this argument if you do not have a reference.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `LetterNotificationResponse`:
 
@@ -511,7 +511,7 @@ public class LetterResponseContent{
 }
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `Notify.Exceptions.NotifyClientException` and an error code.
 
@@ -528,9 +528,9 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number.|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
-## Send a precompiled letter
+### Send a precompiled letter
 
-### Method
+#### Method
 
 ```csharp
 LetterNotificationsResponse response = client.SendPrecompiledLetter(
@@ -540,13 +540,13 @@ LetterNotificationsResponse response = client.SendPrecompiledLetter(
     );
 ```
 
-### Arguments
+#### Arguments
 
-#### clientReference (required)
+##### clientReference (required)
 
 A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
-#### pdfContents (required for the SendPrecompiledLetter method)
+##### pdfContents (required for the SendPrecompiledLetter method)
 
 The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf). The method sends the contents of the file to GOV.UK Notify.
 
@@ -554,12 +554,12 @@ The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF let
 byte[] pdfContents = File.ReadAllBytes("<PDF file path>");
 ```
 
-#### postage (optional)
+##### postage (optional)
 
 You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
 
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `LetterNotificationResponse` with the `id`, `reference` and `postage`:
 
@@ -573,7 +573,7 @@ public LetterResponseContent content;  // null for this response
 
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `Notify.Exceptions.NotifyClientException` containing the relevant error code:
 
@@ -592,13 +592,13 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |N/A|`"message":"reference cannot be null or empty"`|Populate the reference parameter|
 |N/A|`"message":"precompiledPDF cannot be null or empty"`|Send a PDF file with data in it|
 
-# Get message status
+## Get message status
 
 Message status depends on the type of message you have sent.
 
 You can only get the status of messages that are 7 days old or newer.
 
-## Status - email
+### Status - email
 
 |Status|Information|
 |:---|:---|
@@ -607,7 +607,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Delivered|The message was successfully delivered.|
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again."|
 
-## Status - text message
+### Status - text message
 
 |Status|Information|
 |:---|:---|
@@ -618,7 +618,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Delivered|The message was successfully delivered.|
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure."|
 
-## Status - letter
+### Status - letter
 
 |Status|information|
 |:---|:---|
@@ -626,7 +626,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Accepted|GOV.UK Notify has sent the letter to the provider to be printed.|
 |Received|The provider has printed and dispatched the letter.|
 
-## Status - precompiled letter
+### Status - precompiled letter
 
 |Status|information|
 |:---|:---|
@@ -634,26 +634,26 @@ You can only get the status of messages that are 7 days old or newer.
 |Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |Validation failed|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf) for more information.|
 
-## Get the status of one message
+### Get the status of one message
 
 You can only get the status of messages that are 7 days old or newer.
 
-### Method
+#### Method
 
 ```csharp
 Notification notification = client.GetNotificationById(notificationId);
 ```
 
-### Arguments
+#### Arguments
 
-#### notificationId (required)
+##### notificationId (required)
 
 The ID of the notification. To find the notification ID, you can either:
 
 * check the response to the [original notification method call](#response)
 * [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notification`.
 
@@ -690,7 +690,7 @@ public class Template
 
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `Notify.Exceptions.NotifyClientException` and an error code:
 
@@ -702,23 +702,23 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|
 
 
-## Get the status of multiple messages
+### Get the status of multiple messages
 
 This API call returns the status of multiple messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `olderThanId` argument.
 
 You can only get messages that are 7 days old or newer.
 
-### Method
+#### Method
 
 ```csharp
 NotificationList notifications = client.GetNotifications(templateType, status, reference, olderThanId, includeSpreadsheetUploads);
 ```
 
-### Arguments
+#### Arguments
 
 You can leave out these arguments to ignore these filters.
 
-#### templateType (optional)
+##### templateType (optional)
 
 You can filter by:
 
@@ -726,7 +726,7 @@ You can filter by:
 * `sms`
 * `letter`
 
-#### status (optional)
+##### status (optional)
 
 You can filter by each:
 
@@ -737,7 +737,7 @@ You can filter by each:
 
 You can leave out this argument to ignore this filter.
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you can create if you need to. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. For example:
 
@@ -745,7 +745,7 @@ A unique identifier you can create if you need to. This reference identifies a s
 string reference = "STRING";
 ```
 
-#### olderThanId (optional)
+##### olderThanId (optional)
 
 Input the ID of a notification into this argument to return the next 250 received notifications older than the given ID. For example:
 
@@ -757,7 +757,7 @@ If you leave out this argument, the client returns the most recent 250 notificat
 
 The client only returns notifications that are 7 days old or newer. If the notification specified in this argument is older than 7 days, the client returns an empty response.
 
-#### includeSpreadsheetUploads (optional)
+##### includeSpreadsheetUploads (optional)
 
 Specifies whether the response should include notifications which were sent by uploading a spreadsheet of recipients to Notify.
 
@@ -767,7 +767,7 @@ bool includeSpreadsheetUploads = true;
 
 If you do not pass in this argument it defaults to `false`.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notify.Exceptions.NotifyClientException`.
 
@@ -781,7 +781,7 @@ public class Link {
 }
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `Notify.Exceptions.NotifyClientException` and an error code:
 
@@ -792,9 +792,9 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 
-## Get a PDF for a letter notification
+### Get a PDF for a letter notification
 
-### Method
+#### Method
 
 This returns the pdf contents of a letter notification.
 
@@ -802,20 +802,20 @@ This returns the pdf contents of a letter notification.
 byte[] pdfFile = client.GetPdfForLetter(notificationId)
 ```
 
-### Arguments
+#### Arguments
 
-#### notificationId (required)
+##### notificationId (required)
 
 The ID of the notification. To find the notification ID, you can either:
 
 * check the response to the [original notification method call](#get-the-status-of-one-message-response)
 * [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page
 
-### Response
+#### Response
 
 If the request to the client is successful, the client will return a `byte[]` object containing the raw PDF data.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -831,11 +831,11 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|
 
 
-# Get a template
+## Get a template
 
-## Get a template by ID
+### Get a template by ID
 
-### Method
+#### Method
 
 This returns the latest version of the template.
 
@@ -845,9 +845,9 @@ TemplateResponse response = client.GetTemplateById(
 );
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it. For example:
 
@@ -855,7 +855,7 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 string templateId: "f33517ff-2a88-4f6e-b855-c550268ce08a";
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `TemplateResponse`.
 
@@ -873,7 +873,7 @@ public String letter_contact_block; // null if not a letter template or contact 
 ```
 
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `HTTPError` and an error code:
 
@@ -885,9 +885,9 @@ If the request is not successful, the client returns an `HTTPError` and an error
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-arguments-templateid-required)|
 
 
-## Get a template by ID and version
+### Get a template by ID and version
 
-### Method
+#### Method
 
 ```csharp
 TemplateResponse response = client.GetTemplateByIdAndVersion(
@@ -896,9 +896,9 @@ TemplateResponse response = client.GetTemplateByIdAndVersion(
 );
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it. For example:
 
@@ -906,11 +906,11 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 string templateId: "f33517ff-2a88-4f6e-b855-c550268ce08a";
 ```
 
-#### version (required)
+##### version (required)
 
 The version number of the template.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `TemplateResponse`.
 
@@ -927,7 +927,7 @@ public String subject; // null if an sms message
 public String letter_contact_block; // null if not a letter template or contact block not set for letter
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `Notify.Exceptions.NotifyClientException` and an error code:
 
@@ -939,9 +939,9 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-and-version-arguments-templateid-required) and [version](#version-required)|
 
 
-## Get all templates
+### Get all templates
 
-### Method
+#### Method
 
 This returns the latest version of all templates.
 
@@ -951,9 +951,9 @@ TemplateList response = client.GetAllTemplates(
 );
 ```
 
-### Arguments
+#### Arguments
 
-#### templateType (optional)
+##### templateType (optional)
 
 If left out, the method returns all templates. Otherwise you can filter by:
 
@@ -961,7 +961,7 @@ If left out, the method returns all templates. Otherwise you can filter by:
 - `sms`
 - `letter`
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `TemplateList`.
 
@@ -975,9 +975,9 @@ If no templates exist for a template type or there no templates for a service, t
 List<TemplateResponse> templates; // empty list of templates
 ```
 
-## Generate a preview template
+### Generate a preview template
 
-### Method
+#### Method
 
 This generates a preview version of a template.
 
@@ -990,9 +990,9 @@ TemplatePreviewResponse response = client.GenerateTemplatePreview(
 
 The parameters in the personalisation argument must match the placeholder fields in the actual template. The API notification client ignores any extra fields in the method.
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it. For example:
 
@@ -1000,7 +1000,7 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 string templateId: "f33517ff-2a88-4f6e-b855-c550268ce08a";
 ```
 
-#### personalisation (required)
+##### personalisation (required)
 
 If a template has placeholder fields for personalised information such as name or reference number, you need to provide their values in a `Dictionary`. For example:
 
@@ -1013,7 +1013,7 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 
 You can leave out this argument if a template does not have any placeholder fields for personalised information.
 
-### Response
+#### Response
 
 If the request to the client is successful, you receive a `TemplatePreviewResponse` response.
 
@@ -1025,7 +1025,7 @@ public String body;
 public String subject; // null if a sms message
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `Notify.Exceptions.NotifyClientException` and an error code:
 
@@ -1037,7 +1037,7 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 
 
-# Get received text messages
+## Get received text messages
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `olderThanId` argument.
 
@@ -1045,21 +1045,21 @@ You can only get the status of messages that are 7 days old or newer.
 
 You can also set up [callbacks](#callbacks) for received text messages.
 
-## Enable received text messages
+### Enable received text messages
 
 Contact the GOV.UK Notify team using the [support page](https://www.notifications.service.gov.uk/support) or [chat to us on Slack](https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC) to request a unique number for text message replies.
 
-## Get a page of received text messages
+### Get a page of received text messages
 
-### Method
+#### Method
 
 ```csharp
 ReceivedTextListResponse response = client.GetReceivedTexts(olderThanId);
 ```
 
-### Arguments
+#### Arguments
 
-#### olderThanId (optional)
+##### olderThanId (optional)
 
 Input the ID of a notification into this argument to return the next 250 received notifications older than the given ID. For example:
 
@@ -1071,7 +1071,7 @@ If you leave out the `olderThanId` argument, the client returns the most recent 
 
 The client only returns notifications that are 7 days old or newer. If the notification specified in this argument is older than 7 days, the client returns an empty `ReceivedTextListResponse` response.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `ReceivedTextListResponse` that returns all received text messages.
 
@@ -1095,7 +1095,7 @@ public String content;
 ```
 If the notification specified in the `olderThanId` argument is older than 7 days, the client returns an empty `ReceivedTextListResponse` response.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `Notify.Exceptions.NotifyClientException` and an error code.
 


### PR DESCRIPTION
This changes the headings so that there is only one H1 heading. This is part of the work to make the tech docs headings accessible.