### PR TITLE
Update JWT to a later version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.0] - 2021-01-27
+
+* Upgrade the JWT dependency. Version 6.x or 7.x of the JWT dependency is now required.
+
 ## [2.9.0] - 2020-07-13
 
 * Add support for a `letter_contact_block` attribute in the `TemplateResponse` schema. This will allow our users to check contact blocks for their letter templates.

--- a/src/Notify/Authentication/Authenticator.cs
+++ b/src/Notify/Authentication/Authenticator.cs
@@ -43,7 +43,8 @@ namespace Notify.Authentication
                 IDateTimeProvider provider = new UtcDateTimeProvider();
                 IJwtValidator validator = new JwtValidator(serializer, provider);
                 IBase64UrlEncoder urlEncoder = new JwtBase64UrlEncoder();
-                IJwtDecoder decoder = new JwtDecoder(serializer, validator, urlEncoder);
+                IJwtAlgorithm algorithm = new HMACSHA256Algorithm();
+                IJwtDecoder decoder = new JwtDecoder(serializer, validator, urlEncoder, algorithm);
 
                 var jsonPayload = decoder.DecodeToObject<IDictionary<string, object>>(token, secret, verify: true);
 
@@ -52,7 +53,7 @@ namespace Notify.Authentication
             catch (Exception e) when (e is SignatureVerificationException || e is ArgumentException)
             {
                 throw new NotifyAuthException(e.Message);
-            } 
+            }
         }
 
         public static void ValidateGuids(String[] stringGuids)
@@ -66,5 +67,5 @@ namespace Notify.Authentication
             }
         }
     }
-    
+
 }

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JWT" Version="5.0.1" />
+    <PackageReference Include="JWT" Version="[6.0,7.3]" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>2.9.0</Version>
+    <Version>3.0.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
There have been two major releases since the version we were using. From
version `6.0.0` onwards the `JwtDecoder` takes a fourth argument, the
algorithm. There are no changes to how the code works, but we do need to
pass that argument in.

I've tested this change against the integration tests and it works with
versions 6.x and 7.x of JWT, so have let people use either instead of
pinning too precisely.