### PR TITLE
Fix compile error by pinning JWT more precisely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0] - 2021-02-08
+
+* Fixed an issue when importing the JWT dependency by pinning the version to 7.x. It is not possible to support both version 6.x and 7.x of JWT because version 7.0 introduced a breaking change.
+
 ## [3.0.0] - 2021-01-27
 
 * Upgrade the JWT dependency. Version 6.x or 7.x of the JWT dependency is now required.

--- a/src/Notify/Authentication/Authenticator.cs
+++ b/src/Notify/Authentication/Authenticator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using JWT;
 using JWT.Algorithms;
+using JWT.Exceptions;
 using JWT.Serializers;
 using Notify.Exceptions;
 

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>3.0.0</Version>
+    <Version>4.0.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JWT" Version="[6.0,7.3]" />
+    <PackageReference Include="JWT" Version="[7.0,8.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />


### PR DESCRIPTION
This fixes the issue introduced in version 3.0.0. Version 3.0.0 allowed
the JWT dependency to be version 6.x or 7.x, however version 7.0
introduced a breaking change which meant that the project would not
compile.

TODO: look at why the integration tests did appear to pass with version
7.x before.