### PR TITLE
Upgrade dockerfile used for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+FROM mcr.microsoft.com/dotnet/sdk:3.1
 
 RUN \
     echo "Install base packages" \


### PR DESCRIPTION
We were using 2.1 of .NET core but this is not end of life.

You can see on https://hub.docker.com/_/microsoft-dotnet-sdk that
3.1 is long term support.

Also note, that the repo name has changed as per
https://github.com/dotnet/dotnet-docker/issues/2375.

Also note, I could have upgraded us to 5.1 but I went for 3.1 for two
reasons
- it's a smaller change
- good to know that we support the oldest .net stuff so we don't add
  anything in that is only supported by newer versions

However, I could be easily persuaded to choose 5.1 instead.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/Notify/Notify.csproj`)
