### PR TITLE
Downgrade docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:2.1
 
 RUN \
     echo "Install base packages" \


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->
In #138 I
thought that 2.1 was no longer supported. This was incorrect. It is
supported until the end of August as per
https://dotnet.microsoft.com/platform/support/policy/dotnet-core

This, combined with the fact that actually if you run `make
test-with-docker` you will see that the change I added was broken and
the tests fail in docker.

Therefore by downgrading we support the lowest version possible and our
tests are fixed in docker. Win, Win.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/Notify/Notify.csproj`)
