### PR TITLE
make appveyor.txt point to new test source

### DIFF
--- a/appveyor.txt
+++ b/appveyor.txt
@@ -30,6 +30,6 @@ environment:
     secure: KGEhHJcNoRlFXpb9CjrmDwiHK7CdAD3Md50k14/KNueHROXZiQdDQ9K47DKkAT+z4+914AB/o6ZF6X4r6oTSsw==
   pullId: 0
 build: off
-test_script: dotnet test C:\projects\notifications-net-client\src\Notify.Tests -c=Release
+test_script: dotnet test C:\projects\notifications-net-client\src\GovukNotify.Tests -c=Release
 on_success:
 - publish.cmd


### PR DESCRIPTION
appveyor pull the appveyor.txt file from master, which contains instructions on how to test the code. Since https://github.com/alphagov/notifications-net-client/pull/141 changes the path of the tests csproj, we need master to look there first before appveyor will be able to test it.
