### PR TITLE
Update DOCUMENTATION.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -20,7 +20,8 @@ You can install the GOV.UK Notify client package using either the command line o
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
-    Version 2.5.0 will only work if your code is asynchronous. We have fixed this issue in version 2.5.2. <a href= "https://www.notifications.service.gov.uk/support/ask-question-give-feedback">Contact us</a> if you have any problems.
+      If you require an older version of our API client earlier than 4.0.0, download an older version from
+      <a href="https://github.com/alphagov/notifications-net-client/releases">Github</a> [external link]
   </strong>
 </div>
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -20,7 +20,7 @@ You can install the GOV.UK Notify client package using either the command line o
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
-      If you require an older version of our API client earlier than 4.0.0, download an older version from
+      If you need a version of our API client older than 4.0.0, you should download it from
       <a href="https://github.com/alphagov/notifications-net-client/releases">Github</a> [external link]
   </strong>
 </div>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -12,7 +12,7 @@ Refer to the [client changelog](https://github.com/alphagov/notifications-net-cl
 
 ### Install the client
 
-The GOV.UK Notify client deploys to [Nuget.org](https://nuget.org/) [external link].
+The GOV.UK Notify client can be installed from [Nuget.org](https://www.nuget.org/packages/GovukNotify/) [external link].
 
 You can install the GOV.UK Notify client package using either the command line or Microsoft Visual Studio.
 


### PR DESCRIPTION
link to the actual package, not the nuget.org home page

I'm not entirely sure about whether the `nuget` command line commands are still relevant - there's a `nuget.exe` available for working from the command line, but we're talking about the "console", which appears to be a powershell console built into visual studio (not available on mac). so not sure if we should have the powershell command rather than the nuget.exe command? The powershell command is the default method as shown on nuget.org (before `dotnet` cli, editing the csproj directly, and a couple of other methods im not familiar with

![image](https://user-images.githubusercontent.com/5020841/112313860-3eba8800-8ca0-11eb-82a7-231489c0cf26.png)


https://docs.microsoft.com/en-us/nuget/consume-packages/install-use-packages-powershell?view=vsmac-2019

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
