### PR TITLE
Add permanent-failure status for letters

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -622,9 +622,10 @@ You can only get the status of messages that are 7 days old or newer.
 
 |Status|information|
 |:---|:---|
-|#Failed|The only failure status that applies to letters is `technical-failure`. GOV.UK Notify had an unexpected error while sending to our printing provider.|
 |#Accepted|GOV.UK Notify has sent the letter to the provider to be printed.|
 |#Received|The provider has printed and dispatched the letter.|
+|#technical-failure|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#permanent-failure|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Status - precompiled letter
 
@@ -633,6 +634,8 @@ You can only get the status of messages that are 7 days old or newer.
 |#Pending virus check|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |#Validation failed|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
+|#technical-failure|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#permanent-failure|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Get the status of one message
 


### PR DESCRIPTION
If a letter passes our validation but the print provider can not print the letter we should mark it as permanent-failure. An error message for permanent-failure is being added to the UI.
Technical-failure had the wrong message and validation failure will not show the pdf because the letter is in the wrong bucket.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
