### PR TITLE
Increase supported .NET Core version to 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0] - 2022-04-01
+
+* Increase minimum .NET Core version to 3.0
+
 ## [4.0.1] - 2021-04-23
 
 * Fixed a build warning that version 7.0 of the JWT package does not exist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:2.1
+FROM mcr.microsoft.com/dotnet/sdk:3.1
 
 RUN \
     echo "Install base packages" \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 
 .PHONY: build
 build: ## Build project
-	dotnet build -f=netcoreapp2.0
+	dotnet build -f=netcoreapp3.0
 
 .PHONY: integration-test
 integration-test: test=TestCategory=Integration ## Run integration tests
@@ -18,15 +18,15 @@ test: single-test
 
 .PHONY: single-test
 single-test: build ## run a single test. usage: "make single-test test=[test name]"
-	dotnet test ./src/GovukNotify.Tests/GovukNotify.Tests.csproj -f=netcoreapp2.0 --no-build -v=n --filter $(test)
+	dotnet test ./src/GovukNotify.Tests/GovukNotify.Tests.csproj -f=netcoreapp3.0 --no-build -v=n --filter $(test)
 
 .PHONY: build-release
 build-release: ## Build release version
-	dotnet build -c=Release -f=netcoreapp2.0
+	dotnet build -c=Release -f=netcoreapp3.0
 
 .PHONY: build-package
 build-package: build-release ## Build and package NuGet
-	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj /p:TargetFrameworks=netcoreapp2.0 -o=publish
+	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj /p:TargetFrameworks=netcoreapp3.0 -o=publish
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker:  ## Prepare the Docker builder image

--- a/src/GovukNotify.Tests/GovukNotify.Tests.csproj
+++ b/src/GovukNotify.Tests/GovukNotify.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>4.0.1</Version>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0;net462</TargetFrameworks>
+    <Version>5.0.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Netstandard release for net core 2.0, framework 4.6.2</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/alphagov/notifications-net-client/blob/master/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181753597

There are 3 incarnations of .NET:

- .NET Framework is the original Windows-only version of the .NET
runtime and class library.

- .NET Core was then created as a cross-platform version of .NET
and has differences to .NET Framework. It works in Docker.

- .NET Standard is a standard for class libraries that Framework
and Core both adhere to - to allow cross-implementation dev.

.NET Core v2.1 became EOL in August 2021 [^1] and there's no image
to run it on Mac M1 machines. We should bump in any case. Framework
and Standard are still comfortably in support* and changing the min
version of Core doesn't have any impact on those settings.

*.NET Standard is actually being deprecated with .NET Framework 5
[^2].

[^1]: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
[^2]: https://devblogs.microsoft.com/dotnet/the-future-of-net-standard/


<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)