### PR TITLE
Fix release pipeline

### DIFF
--- a/appveyor.txt
+++ b/appveyor.txt
@@ -26,10 +26,8 @@ environment:
     secure: RZKDTRG5V8O7G2l8mbgOX14H7FrFAO0boDQfvUiGZU9J0kBacKiul40FBATZOm04/QxgPjiKQes42dSoNsAcv+hqZq//zb7+tacQ8Ncs6mu8XzESNjnsLtQ0mkmb5cf8
   SMS_SENDER_ID:
     secure: /e26eqAWnfu9m/ysZdTsYaP3ySpsuLaoABQXHHB+M+0Q39OkOxWp7UJ1T5+OAwFP
-  BINTRAY_API_KEY:
-    secure: KGEhHJcNoRlFXpb9CjrmDwiHK7CdAD3Md50k14/KNueHROXZiQdDQ9K47DKkAT+z4+914AB/o6ZF6X4r6oTSsw==
   NUGET_API_KEY:
-    secure: rKEXiPmMrl+EKXQNn0h7OGNW/cb4AHT4MBZoeAUdroSmvjW99wD3SmYzRiU5+R+E
+    secure: pdTFB380I1f6886ekz3rJLkqW+/zETcltPg3xdhTQ24SPMdknU81dvk4nQK8pP+i
   pullId: 0
 build: off
 image: Visual Studio 2019

--- a/publish.cmd
+++ b/publish.cmd
@@ -8,8 +8,8 @@ IF %publish% NEQ true (
 
 dotnet pack -c=Release %APPVEYOR_BUILD_FOLDER%\src\GovukNotify\GovukNotify.csproj -o=publish
 
-FOR %%i IN ("%APPVEYOR_BUILD_FOLDER%/src/GovukNotify/publish/*.nupkg") DO (
+FOR %%i IN ("%APPVEYOR_BUILD_FOLDER%/publish/*.nupkg") DO (
     set filename=%%~nxi
 )
 
-nuget push "%APPVEYOR_BUILD_FOLDER%/src/GovukNotify/publish/%filename%" -Source https://api.nuget.org/v3/index.json -apikey %NUGET_API_KEY%
+nuget push "%APPVEYOR_BUILD_FOLDER%/publish/%filename%" -Source https://api.nuget.org/v3/index.json -apikey %NUGET_API_KEY%


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181753597

This fixes a bug in the publish.cmd script and updates the (encrypted)
API key we use for Nuget as the old one had expired.

See the commit messages for more details.