### PR TITLE
Bump target .NET (Core) version to 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [6.0.0] - 2022-04-04
+
+* Increase target .NET Core version to 6 as previous versions are End Of Life.
+
 ## [5.0.0] - 2022-04-01
 
 * Increase minimum .NET Core version to 3.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 RUN \
     echo "Install base packages" \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 
 .PHONY: build
 build: ## Build project
-	dotnet build -f=netcoreapp3.1
+	dotnet build -f=net6
 
 .PHONY: integration-test
 integration-test: test=TestCategory=Integration ## Run integration tests
@@ -18,15 +18,15 @@ test: single-test
 
 .PHONY: single-test
 single-test: build ## run a single test. usage: "make single-test test=[test name]"
-	dotnet test ./src/GovukNotify.Tests/GovukNotify.Tests.csproj -f=netcoreapp3.1 --no-build -v=n --filter $(test)
+	dotnet test ./src/GovukNotify.Tests/GovukNotify.Tests.csproj -f=net6 --no-build -v=n --filter $(test)
 
 .PHONY: build-release
 build-release: ## Build release version
-	dotnet build -c=Release -f=netcoreapp3.1
+	dotnet build -c=Release -f=net6
 
 .PHONY: build-package
 build-package: build-release ## Build and package NuGet
-	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj /p:TargetFrameworks=netcoreapp3.1 -o=publish
+	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj /p:TargetFrameworks=net6 -o=publish
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker:  ## Prepare the Docker builder image

--- a/appveyor.txt
+++ b/appveyor.txt
@@ -30,7 +30,7 @@ environment:
     secure: pdTFB380I1f6886ekz3rJLkqW+/zETcltPg3xdhTQ24SPMdknU81dvk4nQK8pP+i
   pullId: 0
 build: off
-image: Visual Studio 2019
+image: Visual Studio 2022
 test_script: dotnet test C:\projects\notifications-net-client\src\GovukNotify.Tests -c=Release
 on_success:
 - publish.cmd

--- a/src/GovukNotify.Tests/GovukNotify.Tests.csproj
+++ b/src/GovukNotify.Tests/GovukNotify.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6;net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JWT" Version="[7.1,8.0)" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="JWT" Version="[7.1,9)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[10.0.3,14)" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net462</TargetFrameworks>
-    <Version>5.0.0</Version>
+    <TargetFrameworks>netstandard2.0;net6;net462</TargetFrameworks>
+    <Version>6.0.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181753597

This moves us from the old world of .NET Core and .NET Standard to the
new, unifired ".NET". See the first commit for more details.

I've also added another commit to loosen some of the dependency upper
version limits - these are still useful but were out-of-date.

Like [^1] this is a major change in the sense that anyone still working
on projects in older, unsupported incarnations of .NET will have to pin
and older version of this package and won't get future updates.

## How to test

Due to the change in appveyor.txt this needs to be tested by manually
overriding the reference to it in Appveyor - same as in [^1].

[^1]: https://github.com/alphagov/notifications-net-client/pull/156