### PR TITLE
Add details of ‘confirm email address’ and ‘custom retention period’

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -453,7 +453,9 @@ Set the number of weeks you want the file to be available using the `retention_p
 
 You can choose any value between 1 week and 78 weeks.
 
-If you do not do this, the file will be available for the default period of 78 weeks (18 months).
+To use this feature will need version X.X.X of the .NET client library, or a more recent version.
+
+If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
 
 ```csharp
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -415,7 +415,8 @@ byte[] documentContents = File.ReadAllBytes("<file path>");
 Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 {
     { "name", "Foo" },
-    { "link_to_file", NotificationClient.PrepareUpload(documentContents)}
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents)},
+    { "verify_email_before_download", true}
 };
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -402,7 +402,7 @@ From 29 March 2023, we will turn this feature on by default for every file you s
 
 ##### Turn on email address check
 
-To use this feature before 29 March 2023 you will need version X.X.X of the Python client library, or a more recent version.
+To use this feature before 29 March 2023 you will need version X.X.X of the .NET client library, or a more recent version.
 
 To make the recipient confirm their email address before downloading the file, set the `verify_email_before_download` flag to `True`.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -338,7 +338,7 @@ To help protect your files you can also:
 * ask recipients to confirm their email address before downloading
 * choose the length of time that a file is available to download
 
-To turn these features on or off, you will need version X.X.X of the .NET client library or a more recent version.
+To turn these features on or off, you will need version 6.1.0 of the .NET client library or a more recent version.
 
 #### Add contact details to the file download page
 
@@ -402,9 +402,9 @@ From 29 March 2023, we will turn this feature on by default for every file you s
 
 ##### Turn on email address check
 
-To use this feature before 29 March 2023 you will need version X.X.X of the .NET client library, or a more recent version.
+To use this feature before 29 March 2023 you will need version 6.1.0 of the .NET client library, or a more recent version.
 
-To make the recipient confirm their email address before downloading the file, set the `verify_email_before_download` flag to `True`.
+To make the recipient confirm their email address before downloading the file, set the `confirmEmailBeforeDownload` flag to `true`.
 
 You will not need to do this after 29 March.
 
@@ -415,8 +415,7 @@ byte[] documentContents = File.ReadAllBytes("<file path>");
 Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 {
     { "name", "Foo" },
-    { "link_to_file", NotificationClient.PrepareUpload(documentContents)},
-    { "verify_email_before_download", true}
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents, false, true)}
 };
 ```
 
@@ -424,7 +423,7 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 
 If you do not want to use this feature after 29 March 2023, you can turn it off on a file-by-file basis.
 
-To do this you will need version X.X.X of the .NET client library, or a more recent version.
+To do this you will need version 6.1.0 of the .NET client library, or a more recent version.
 
 You should not turn this feature off if you send files that contain:
 
@@ -432,7 +431,7 @@ You should not turn this feature off if you send files that contain:
 * commercially sensitive information
 * information classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the [Government Security Classifications](https://www.gov.uk/government/publications/government-security-classifications) policy
 
-To let the recipient download the file without confirming their email address, set the `verify_email_before_download` flag to `false`.
+To let the recipient download the file without confirming their email address, set the `confirmEmailBeforeDownload` flag to `false`.
 
 
 ```csharp
@@ -442,18 +441,17 @@ byte[] documentContents = File.ReadAllBytes("<file path>");
 Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 {
     { "name", "Foo" },
-    { "link_to_file", NotificationClient.PrepareUpload(documentContents)},
-    { "verify_email_before_download", false}
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents, false, false)}
 };
 ```
 
 #### Choose the length of time that a file is available to download
 
-Set the number of weeks you want the file to be available using the `retention_period` key.
+Set the number of weeks you want the file to be available using the `retentionPeriod` parameter.
 
 You can choose any value between 1 week and 78 weeks.
 
-To use this feature will need version X.X.X of the .NET client library, or a more recent version.
+To use this feature will need version 6.1.0 of the .NET client library, or a more recent version.
 
 If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
 
@@ -464,8 +462,7 @@ byte[] documentContents = File.ReadAllBytes("<file path>");
 Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 {
     { "name", "Foo" },
-    { "link_to_file", NotificationClient.PrepareUpload(documentContents)},
-    { "retention_period", 4 weeks}
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents, false, true, "52 weeks")}
 };
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -329,9 +329,13 @@ If the request is not successful, the client returns a `Notify.Exceptions.Notify
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
-The file will be available for the recipient to download for 18 months.
-
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
+
+For added security, you can ask recipients to confirm their email address before they can download the file.
+
+You can also choose the length of time that a file is available to download. The default period is 78 weeks (18 months).
+
+From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files.
 
 #### Add contact details to the file download page
 
@@ -345,9 +349,9 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
 1. Select __Edit__.
-1. Add a placeholder to the email template using double brackets. For example:
+1. Add a placeholder to the email template using double brackets. For example: "Download your file at: ((link_to_file))"
 
-"Download your file at: ((link_to_file))"
+Your email should also tell recipients how long the file will be available to download.
 
 #### Upload your file
 
@@ -382,6 +386,63 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 {
     { "name", "Foo" },
     { "link_to_file", NotificationClient.PrepareUpload(documentContents, isCsv = true)}
+};
+```
+
+#### Ask recipients to confirm their email address before they can download the file
+
+This feature is currently opt-in only. From 29 March 2023 it will apply to all new files by default, unless you opt out.
+
+##### Opt in
+
+To ask recipients to confirm their email address, set the `verify_email_before_download` flag to `true`.
+
+You will not need to do this after 29 March 2023.
+
+```csharp
+
+byte[] documentContents = File.ReadAllBytes("<file path>");
+
+Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+{
+    { "name", "Foo" },
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents)}
+};
+```
+
+##### Opt out (not recommended)
+
+You should not opt out if you send files that contain personally identifiable information or sensitive information.
+
+If you do not want to use this security feature, set the `verify_email_before_download` flag to `false` by 29 March 2023.
+
+```csharp
+
+byte[] documentContents = File.ReadAllBytes("<file path>");
+
+Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+{
+    { "name", "Foo" },
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents)}
+};
+```
+
+#### Choose the length of time that a file is available to download
+
+Set the number of weeks you want the file to be available using the `retention_period` key.
+
+You can choose any value between 1 week and 78 weeks.
+
+If you do not do this, the file will be available for the default period of 78 weeks (18 months).
+
+```csharp
+
+byte[] documentContents = File.ReadAllBytes("<file path>");
+
+Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+{
+    { "name", "Foo" },
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents)}
 };
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -442,7 +442,8 @@ byte[] documentContents = File.ReadAllBytes("<file path>");
 Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 {
     { "name", "Foo" },
-    { "link_to_file", NotificationClient.PrepareUpload(documentContents)}
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents)},
+    { "verify_email_before_download", false}
 };
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -331,11 +331,14 @@ To send a file by email, add a placeholder to the template then upload a file. T
 
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
 
-For added security, you can ask recipients to confirm their email address before they can download the file.
+Your file will be available to download for a default period of 78 weeks (18 months). From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files. Files sent before 29 March will not be affected.
 
-You can also choose the length of time that a file is available to download. The default period is 78 weeks (18 months).
+To help protect your files you can also:
 
-From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files.
+* ask recipients to confirm their email address before downloading
+* choose the length of time that a file is available to download
+
+To turn these features on or off, you will need version X.X.X of the .NET client library or a more recent version.
 
 #### Add contact details to the file download page
 
@@ -391,13 +394,19 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 
 #### Ask recipients to confirm their email address before they can download the file
 
-This feature is currently opt-in only. From 29 March 2023 it will apply to all new files by default, unless you opt out.
+This new security feature is optional. You should use it if you send files that are sensitive - for example, because they contain personal information about your users.
 
-##### Opt in
+When a recipient clicks the link in the email you’ve sent them, they have to enter their email address. Only someone who knows the recipient’s email address can download the file.
 
-To ask recipients to confirm their email address, set the `verify_email_before_download` flag to `true`.
+From 29 March 2023, we will turn this feature on by default for every file you send. Files sent before 29 March will not be affected.
 
-You will not need to do this after 29 March 2023.
+##### Turn on email address check
+
+To use this feature before 29 March 2023 you will need version X.X.X of the Python client library, or a more recent version.
+
+To make the recipient confirm their email address before downloading the file, set the `verify_email_before_download` flag to `True`.
+
+You will not need to do this after 29 March.
 
 ```csharp
 
@@ -410,11 +419,20 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 };
 ```
 
-##### Opt out (not recommended)
+##### Turn off email address check (not recommended)
 
-You should not opt out if you send files that contain personally identifiable information or sensitive information.
+If you do not want to use this feature after 29 March 2023, you can turn it off on a file-by-file basis.
 
-If you do not want to use this security feature, set the `verify_email_before_download` flag to `false` by 29 March 2023.
+To do this you will need version X.X.X of the Python client library, or a more recent version.
+
+You should not turn this feature off if you send files that contain:
+
+* personally identifiable information
+* commercially sensitive information
+* information classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the [Government Security Classifications](https://www.gov.uk/government/publications/government-security-classifications) policy
+
+To let the recipient download the file without confirming their email address, set the `verify_email_before_download` flag to `false`.
+
 
 ```csharp
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -464,7 +464,8 @@ byte[] documentContents = File.ReadAllBytes("<file path>");
 Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 {
     { "name", "Foo" },
-    { "link_to_file", NotificationClient.PrepareUpload(documentContents)}
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents)},
+    { "retention_period", 4 weeks}
 };
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -424,7 +424,7 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 
 If you do not want to use this feature after 29 March 2023, you can turn it off on a file-by-file basis.
 
-To do this you will need version X.X.X of the Python client library, or a more recent version.
+To do this you will need version X.X.X of the .NET client library, or a more recent version.
 
 You should not turn this feature off if you send files that contain:
 


### PR DESCRIPTION
# Do not merge until the new features are live

This PR updates the ‘Send a file by email’ section of the REST-API documentation.

There are 2 stories in the backlog which describe this work:

* [Update 'send a file by email' API client docs for 'email verification' flow](https://www.pivotaltracker.com/story/show/182942256)
* [Update 'send a file by email' API client docs for custom retention periods](https://www.pivotaltracker.com/story/show/182999152)
