### PR TITLE
Convert http errors to json

### DIFF
--- a/src/GovukNotify.Tests/UnitTests/NotificationClientAsyncUnitTests.cs
+++ b/src/GovukNotify.Tests/UnitTests/NotificationClientAsyncUnitTests.cs
@@ -60,7 +60,7 @@ namespace Notify.Tests.UnitTests
                 AssertValidRequest, status: HttpStatusCode.NotFound);
 
             var ex = Assert.ThrowsAsync<NotifyClientException>(async () => await client.GetNotificationsAsync());
-            Assert.That(ex.Message, Does.Contain("Status code 404. Error: non json response"));
+            Assert.That(ex.Message, Does.Contain("{\"status_code\":404,\"errors\":[{\"error\":\"The following error occured\",\"message\":\"non json response\"}]"));
         }
 
         [Test, Category("Unit"), Category("Unit/NotificationClientAsync")]

--- a/src/GovukNotify.Tests/UnitTests/NotificationClientUnitTests.cs
+++ b/src/GovukNotify.Tests/UnitTests/NotificationClientUnitTests.cs
@@ -60,7 +60,7 @@ namespace Notify.Tests.UnitTests
                 AssertValidRequest, status: HttpStatusCode.NotFound);
 
             var ex = Assert.Throws<NotifyClientException>(() => client.GetNotifications());
-            Assert.That(ex.Message, Does.Contain("Status code 404. Error: non json response"));
+            Assert.That(ex.Message, Does.Contain("{\"status_code\":404,\"errors\":[{\"error\":\"The following error occured\",\"message\":\"non json response\"}]"));
         }
 
         [Test, Category("Unit"), Category("Unit/NotificationClient")]

--- a/src/GovukNotify/Client/BaseClient.cs
+++ b/src/GovukNotify/Client/BaseClient.cs
@@ -117,10 +117,42 @@ namespace Notify.Client
 
         private void HandleHTTPErrors(HttpResponseMessage response, string errorResponseContent)
         {
+            string Exception = "";
+            try
+            {
+                errorResponseContent = 
+                    "{\"status_code\":400,\"errors\":[{\"error\":\"sdfdsfsf\",\"message\":\"sdfdsfsdfdsfsdf\"},{\"error\":\"sdfdsfsf\",\"message\":\"sdfdsfsdfdsfsdf\"}]}";
+                
+                var errorResponse = JsonConvert.DeserializeObject<NotifyHTTPErrorResponse>(errorResponseContent);
+                dynamic errorObject = new
+                {
+                    status_code = errorResponse.getStatusCode(),
+                    errors = errorResponse.getErrorsAsJson()
+                };
+                Exception = JsonConvert.SerializeObject(errorObject);
+            }
+            catch (Exception ex)
+            {
+                dynamic errorObject = new
+                {
+                    status_code = response.StatusCode.GetHashCode(),
+                    errors = errorResponseContent,
+                    exception = ex.Message
+                };
+                Exception = JsonConvert.SerializeObject(errorObject);
+            }
+            finally
+            {
+                throw new NotifyClientException(Exception);
+            }
+        }
+        
+        private void HandleHTTPErrors2(HttpResponseMessage response, string errorResponseContent)
+        {
             try
             {
                 var errorResponse = JsonConvert.DeserializeObject<NotifyHTTPErrorResponse>(errorResponseContent);
-                throw new NotifyClientException("Status code {0}. The following errors occured {1}", errorResponse.getStatusCode(), errorResponse.getErrorsAsJson());
+                throw new NotifyClientException("Status_code {0}. The following errors occured {1}", errorResponse.getStatusCode(), errorResponse.getErrorsAsJson());
             }
             catch (Exception ex)
             {

--- a/src/GovukNotify/Client/BaseClient.cs
+++ b/src/GovukNotify/Client/BaseClient.cs
@@ -120,23 +120,21 @@ namespace Notify.Client
             string Exception = "";
             try
             {
-                errorResponseContent = 
-                    "{\"status_code\":400,\"errors\":[{\"error\":\"sdfdsfsf\",\"message\":\"sdfdsfsdfdsfsdf\"},{\"error\":\"sdfdsfsf\",\"message\":\"sdfdsfsdfdsfsdf\"}]}";
-                
                 var errorResponse = JsonConvert.DeserializeObject<NotifyHTTPErrorResponse>(errorResponseContent);
-                dynamic errorObject = new
-                {
-                    status_code = errorResponse.getStatusCode(),
-                    errors = errorResponse.getErrorsAsJson()
-                };
-                Exception = JsonConvert.SerializeObject(errorObject);
+                Exception = JsonConvert.SerializeObject(errorResponse);
             }
             catch (Exception ex)
             {
                 dynamic errorObject = new
                 {
                     status_code = response.StatusCode.GetHashCode(),
-                    errors = errorResponseContent,
+                    errors = new []
+                    {
+                        new {
+                            error = "The following error occured",
+                            message = errorResponseContent
+                        }
+                    },
                     exception = ex.Message
                 };
                 Exception = JsonConvert.SerializeObject(errorObject);
@@ -147,19 +145,6 @@ namespace Notify.Client
             }
         }
         
-        private void HandleHTTPErrors2(HttpResponseMessage response, string errorResponseContent)
-        {
-            try
-            {
-                var errorResponse = JsonConvert.DeserializeObject<NotifyHTTPErrorResponse>(errorResponseContent);
-                throw new NotifyClientException("Status_code {0}. The following errors occured {1}", errorResponse.getStatusCode(), errorResponse.getErrorsAsJson());
-            }
-            catch (Exception ex)
-            {
-                throw new NotifyClientException("Status code {0}. Error: {1}, Exception: {2}", response.StatusCode.GetHashCode(), errorResponseContent, ex.Message);
-            }
-        }
-
         public Tuple<string, string> ExtractServiceIdAndApiKey(string fromApiKey)
         {
             if (fromApiKey.Length < 74 || string.IsNullOrWhiteSpace(fromApiKey) || fromApiKey.Contains(" "))

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;net6;net462</TargetFrameworks>
-    <Version>6.1.0</Version>
+    <Version>6.1.1</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/GovukNotify/Models/Responses/NotifyHTTPErrorResponse.cs
+++ b/src/GovukNotify/Models/Responses/NotifyHTTPErrorResponse.cs
@@ -12,14 +12,16 @@ namespace Notify.Models.Responses
         [JsonProperty("errors")]
         private List<NotifyHTTPError> errors;
 
+        [JsonProperty("exception")]
+        private string exception;
+        
         public string getStatusCode()
-        {
-            return statusCode;
-        }
+            => statusCode;
 
-        public string getErrorsAsJson()
-        {
-            return JsonConvert.SerializeObject(errors, Formatting.Indented);
-        }
+        public string getException()
+            => exception;
+
+        public string getErrorsAsJson(Formatting format = Formatting.Indented)
+            => JsonConvert.SerializeObject(errors, format);
     }
 }


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?

When the Notify service throws a 'NotifyClientException' Exception, the returned string is unparsable due to inconsistent json formatting.

Examples below:
> {"Status code 400. Error: {\"errors\":[{\"error\":\"BadRequestError\",\"message\":\"Can\\u2019t send to this recipient using a team-only API key\"}],\"status_code\":400}\n, Exception: Status code 400. The following errors occured [\r\n  {\r\n    \"error\": \"BadRequestError\",\r\n    \"message\": \"Can’t send to this recipient using a team-only API key\"\r\n  }\r\n]"}

> {"Status code 400. Error: {\"errors\":[{\"error\":\"ValidationError\",\"message\":\"phone_number Not enough digits\"}],\"status_code\":400}\n, Exception: Status code 400. The following errors occured [\r\n  {\r\n    \"error\": \"ValidationError\",\r\n    \"message\": \"phone_number Not enough digits\"\r\n  }\r\n]"}


Change converts output from BaseClient.HandleHTTPErrors to return a standard JSON object of type 'NotifyHTTPErrorResponse' to allow Json Deserialisation.
> {"status_code":"400", "errors": [{\"error\":\"ValidationError\",\"message\":\"phone_number Too many digits\"}],"exception":null}

> {"status_code":"400", "errors":[{\"error\":\"ValidationError\",\"message\":\"phone_number Not enough digits\"}],"exception":null}


Related issue thread: https://github.com/alphagov/notifications-net-client/issues/161

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
