### PR TITLE
Update DOCUMENTATION.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -453,7 +453,7 @@ You can choose any value between 1 week and 78 weeks.
 
 To use this feature will need version 6.1.0 of the .NET client library, or a more recent version.
 
-If you do not choose a value, the file will be available for the default period of 26 weeks (6 months).
+If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
 
 ```csharp
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -331,7 +331,7 @@ To send a file by email, add a placeholder to the template then upload a file. T
 
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
 
-Your file will be available to download for a default period of 78 weeks (18 months). From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files. Files sent before 29 March will not be affected.
+Your file will be available to download for a default period of 78 weeks (18 months). From 12 April 2023 we will reduce this to 26 weeks (6 months) for all new files. Files sent before 12 April will not be affected.
 
 To help protect your files you can also:
 
@@ -398,15 +398,15 @@ This new security feature is optional. You should use it if you send files that 
 
 When a recipient clicks the link in the email you’ve sent them, they have to enter their email address. Only someone who knows the recipient’s email address can download the file.
 
-From 29 March 2023, we will turn this feature on by default for every file you send. Files sent before 29 March will not be affected.
+From 12 April 2023, we will turn this feature on by default for every file you send. Files sent before 12 April will not be affected.
 
 ##### Turn on email address check
 
-To use this feature before 29 March 2023 you will need version 6.1.0 of the .NET client library, or a more recent version.
+To use this feature before 12 April 2023 you will need version 6.1.0 of the .NET client library, or a more recent version.
 
 To make the recipient confirm their email address before downloading the file, set the `confirmEmailBeforeDownload` flag to `true`.
 
-You will not need to do this after 29 March.
+You will not need to do this after 12 April.
 
 ```csharp
 
@@ -421,7 +421,7 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 
 ##### Turn off email address check (not recommended)
 
-If you do not want to use this feature after 29 March 2023, you can turn it off on a file-by-file basis.
+If you do not want to use this feature after 12 April 2023, you can turn it off on a file-by-file basis.
 
 To do this you will need version 6.1.0 of the .NET client library, or a more recent version.
 
@@ -453,7 +453,7 @@ You can choose any value between 1 week and 78 weeks.
 
 To use this feature will need version 6.1.0 of the .NET client library, or a more recent version.
 
-If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
+If you do not choose a value, the file will be available for the default period of 26 weeks (6 months).
 
 ```csharp
 


### PR DESCRIPTION
This PR bumps the date that we change the ‘Send files by email’ defaults for:

email address check
file retention period
The new date is 12 April 2023.

On 12 April we will update the content about defaults.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
