### PR TITLE
Added support for cancellation tokens

### DIFF
--- a/src/GovukNotify.Tests/GovukNotify.Tests.csproj
+++ b/src/GovukNotify.Tests/GovukNotify.Tests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -8,6 +8,8 @@
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>See https://github.com/alphagov/notifications-net-client/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <RootNamespace>Notify</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">

--- a/src/GovukNotify/Interfaces/IAsyncNotificationClient.cs
+++ b/src/GovukNotify/Interfaces/IAsyncNotificationClient.cs
@@ -1,32 +1,33 @@
 ﻿using Notify.Models;
 using Notify.Models.Responses;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Notify.Interfaces
 {
     public interface IAsyncNotificationClient : IBaseClient
     {
-        Task<TemplatePreviewResponse> GenerateTemplatePreviewAsync(string templateId, Dictionary<string, dynamic> personalisation = null);
+        Task<TemplatePreviewResponse> GenerateTemplatePreviewAsync(string templateId, Dictionary<string, dynamic> personalisation = null, CancellationToken cancellationToken = default);
 
-        Task<TemplateList> GetAllTemplatesAsync(string templateType = "");
+        Task<TemplateList> GetAllTemplatesAsync(string templateType = "", CancellationToken cancellationToken = default);
 
-        Task<Notification> GetNotificationByIdAsync(string notificationId);
+        Task<Notification> GetNotificationByIdAsync(string notificationId, CancellationToken cancellationToken = default);
 
-        Task<NotificationList> GetNotificationsAsync(string templateType = "", string status = "", string reference = "", string olderThanId = "", bool includeSpreadsheetUploads = false);
+        Task<NotificationList> GetNotificationsAsync(string templateType = "", string status = "", string reference = "", string olderThanId = "", bool includeSpreadsheetUploads = false, CancellationToken cancellationToken = default);
 
-        Task<ReceivedTextListResponse> GetReceivedTextsAsync(string olderThanId = "");
+        Task<ReceivedTextListResponse> GetReceivedTextsAsync(string olderThanId = "", CancellationToken cancellationToken = default);
 
-        Task<TemplateResponse> GetTemplateByIdAsync(string templateId);
+        Task<TemplateResponse> GetTemplateByIdAsync(string templateId, CancellationToken cancellationToken = default);
 
-        Task<TemplateResponse> GetTemplateByIdAndVersionAsync(string templateId, int version = 0);
+        Task<TemplateResponse> GetTemplateByIdAndVersionAsync(string templateId, int version = 0, CancellationToken cancellationToken = default);
 
-        Task<SmsNotificationResponse> SendSmsAsync(string mobileNumber, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string smsSenderId = null);
+        Task<SmsNotificationResponse> SendSmsAsync(string mobileNumber, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string smsSenderId = null, CancellationToken cancellationToken = default);
 
-        Task<EmailNotificationResponse> SendEmailAsync(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string emailReplyToId = null);
+        Task<EmailNotificationResponse> SendEmailAsync(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string emailReplyToId = null, CancellationToken cancellationToken = default);
 
-        Task<LetterNotificationResponse> SendLetterAsync(string templateId, Dictionary<string, dynamic> personalisation, string clientReference = null);
+        Task<LetterNotificationResponse> SendLetterAsync(string templateId, Dictionary<string, dynamic> personalisation, string clientReference = null, CancellationToken cancellationToken = default);
 
-        Task<LetterNotificationResponse> SendPrecompiledLetterAsync(string clientReference, byte[] pdfContents, string postage);
+        Task<LetterNotificationResponse> SendPrecompiledLetterAsync(string clientReference, byte[] pdfContents, string postage, CancellationToken cancellationToken = default);
     }
 }

--- a/src/GovukNotify/Interfaces/IBaseClient.cs
+++ b/src/GovukNotify/Interfaces/IBaseClient.cs
@@ -1,16 +1,17 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Notify.Interfaces
 {
     public interface IBaseClient
     {
-        Task<string> GET(string url);
+        Task<string> GET(string url, CancellationToken cancellationToken = default);
 
-        Task<string> POST(string url, string json);
+        Task<string> POST(string url, string json, CancellationToken cancellationToken = default);
 
-        Task<string> MakeRequest(string url, HttpMethod method, HttpContent content = null);
+        Task<string> MakeRequest(string url, HttpMethod method, HttpContent content = null, CancellationToken cancellationToken = default);
 
         Tuple<string, string> ExtractServiceIdAndApiKey(string fromApiKey);
 

--- a/src/GovukNotify/Interfaces/IHttpClient.cs
+++ b/src/GovukNotify/Interfaces/IHttpClient.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Notify.Interfaces
 {
     public interface IHttpClient : IDisposable
     {
-        Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
+        Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
 
         Uri BaseAddress { get; set; }
 


### PR DESCRIPTION
## What problem does the pull request solve?

Fixes #176 by adding support for passing `CancellationToken` parameters to asynchronous methods.

Also fixes #130 - rather than accessing a `Task` result directly the task should be `await`ed.

These changes allow early cancellation of requests.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
