### PR TITLE
Allow setting custom filenames for documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.0.0] - 2023-12-27
+
+* Removes the `isCsv` parameter from `PrepareUpload`
+* Adds a `filename` parameter to `PrepareUpload`; see documentation for more details.
+
 ## [6.1.0] - 2022-09-27
 
 * Add support for new security features when sending a file by email:

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -377,13 +377,20 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 
 #### Set the filename
 
-You can provide a filename to set when the recipient downloads the file. If this is not provided, a random filename will be generated.
+To do this you will need version 7.0.0 of the .NET client library, or a more recent version.
 
-Choosing a sensible filename can help users understand what the file contains, and find it again later.
+You should provide a filename when you upload your file.
 
-You do not have to set this, but we strongly recommend it.
+The filename should tell the recipient what the file contains. A memorable filename can help the recipient to find the file again later.
 
-The filename must include the correct file extension, such as `.csv` for a CSV file. If you include the wrong file extension, users may not be able to open your file.
+The filename must end with a file extension. For example, `.csv` for a CSV file. If you include the wrong file extension, recipients may not be able to open your file.
+
+If you do not provide a filename for your file, Notify will:
+
+* generate a random filename
+* try to add the correct file extension
+
+If Notify cannot add the correct file extension, recipients may not be able to open your file.
 
 ```csharp
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -375,9 +375,15 @@ Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 };
 ```
 
-##### CSV files
+#### Set the filename
 
-Uploads for CSV files should use the `isCsv` parameter on the `PrepareUpload()` function. For example:
+You can provide a filename to set when the recipient downloads the file. If this is not provided, a random filename will be generated.
+
+Choosing a sensible filename can help users understand what the file contains, and find it again later.
+
+You do not have to set this, but we strongly recommend it.
+
+The filename must include the correct file extension, such as `.csv` for a CSV file. If you include the wrong file extension, users may not be able to open your file.
 
 ```csharp
 
@@ -386,7 +392,7 @@ byte[] documentContents = File.ReadAllBytes("<file path>");
 Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 {
     { "name", "Foo" },
-    { "link_to_file", NotificationClient.PrepareUpload(documentContents, isCsv = true)}
+    { "link_to_file", NotificationClient.PrepareUpload(documentContents, filename = "2023-12-25-daily-report.csv")}
 };
 ```
 

--- a/src/GovukNotify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
+++ b/src/GovukNotify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
@@ -44,7 +44,7 @@ namespace Notify.Tests.IntegrationTests
 		const String TEST_LETTER_BODY = "Hello Foo";
 		const String TEST_LETTER_SUBJECT = "Main heading";
 
-        [SetUp]
+		[SetUp]
 		[Test, Category("Integration"), Category("Integration/NotificationClientAsync")]
 		public void SetUp()
 		{
@@ -169,15 +169,15 @@ namespace Notify.Tests.IntegrationTests
 
 			string reference = System.Guid.NewGuid().ToString();
 			string postage = "first";
-                        byte[] pdfContents;
-                        try
-                        {
-                            pdfContents = File.ReadAllBytes("../../../IntegrationTests/test_files/one_page_pdf.pdf");
-                        }
-                        catch (DirectoryNotFoundException)
-                        {
-                            pdfContents = File.ReadAllBytes("IntegrationTests/test_files/one_page_pdf.pdf");
-                        }
+			byte[] pdfContents;
+			try
+			{
+				pdfContents = File.ReadAllBytes("../../../IntegrationTests/test_files/one_page_pdf.pdf");
+			}
+			catch (DirectoryNotFoundException)
+			{
+				pdfContents = File.ReadAllBytes("IntegrationTests/test_files/one_page_pdf.pdf");
+			}
 
 			LetterNotificationResponse response = await this.client.SendPrecompiledLetterAsync(reference, pdfContents, postage);
 
@@ -243,7 +243,7 @@ namespace Notify.Tests.IntegrationTests
 
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 			{
-				{ "name", NotificationClient.PrepareUpload(pdfContents, true, true, "4 weeks") }
+				{ "name", NotificationClient.PrepareUpload(pdfContents, "report.csv", true, "4 weeks") }
 			};
 
 			EmailNotificationResponse response =

--- a/src/GovukNotify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
+++ b/src/GovukNotify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
@@ -172,15 +172,15 @@ namespace Notify.Tests.IntegrationTests
 
 			string reference = System.Guid.NewGuid().ToString();
 			string postage = "first";
-                        byte[] pdfContents;
-                        try
-                        {
-                            pdfContents = File.ReadAllBytes("../../../IntegrationTests/test_files/one_page_pdf.pdf");
-                        }
-                        catch (DirectoryNotFoundException)
-                        {
-                            pdfContents = File.ReadAllBytes("IntegrationTests/test_files/one_page_pdf.pdf");
-                        }
+			byte[] pdfContents;
+			try
+			{
+				pdfContents = File.ReadAllBytes("../../../IntegrationTests/test_files/one_page_pdf.pdf");
+			}
+			catch (DirectoryNotFoundException)
+			{
+				pdfContents = File.ReadAllBytes("IntegrationTests/test_files/one_page_pdf.pdf");
+			}
 
 			LetterNotificationResponse response = this.client.SendPrecompiledLetter(reference, pdfContents, postage);
 
@@ -246,7 +246,7 @@ namespace Notify.Tests.IntegrationTests
 
 			Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
 			{
-				{ "name", NotificationClient.PrepareUpload(pdfContents, true, true, "4 weeks") }
+				{ "name", NotificationClient.PrepareUpload(pdfContents, "report.csv", true, "4 weeks") }
 			};
 
 			EmailNotificationResponse response =
@@ -524,13 +524,19 @@ namespace Notify.Tests.IntegrationTests
 			byte[] pdfData = null;
 			for (int i = 0; i < 15; i++)
 			{
-				try {
+				try
+				{
 					pdfData = this.client.GetPdfForLetter(this.letterNotificationId);
 					break;
-				} catch (NotifyClientException e) {
-					if (!e.Message.Contains("PDFNotReadyError")) {
+				}
+				catch (NotifyClientException e)
+				{
+					if (!e.Message.Contains("PDFNotReadyError"))
+					{
 						throw e;
-					} else {
+					}
+					else
+					{
 						Thread.Sleep(3000);
 					}
 				}

--- a/src/GovukNotify.Tests/UnitTests/NotificationClientUnitTests.cs
+++ b/src/GovukNotify.Tests/UnitTests/NotificationClientUnitTests.cs
@@ -285,7 +285,7 @@ namespace Notify.Tests.UnitTests
         {
             const string type = "sms";
             MockRequest(Constants.fakeTemplateSmsListResponseJson,
-                         client.GET_ALL_TEMPLATES_URL+ client.TYPE_PARAM + type, AssertValidRequest);
+                         client.GET_ALL_TEMPLATES_URL + client.TYPE_PARAM + type, AssertValidRequest);
 
             client.GetAllTemplates(type);
         }
@@ -296,7 +296,7 @@ namespace Notify.Tests.UnitTests
             const string type = "email";
 
             MockRequest(Constants.fakeTemplateEmailListResponseJson,
-                         client.GET_ALL_TEMPLATES_URL+ client.TYPE_PARAM + type, AssertValidRequest);
+                         client.GET_ALL_TEMPLATES_URL + client.TYPE_PARAM + type, AssertValidRequest);
 
             client.GetAllTemplates(type);
         }
@@ -306,7 +306,7 @@ namespace Notify.Tests.UnitTests
         {
             var expectedResponse = JsonConvert.DeserializeObject<TemplateList>(Constants.fakeTemplateEmptyListResponseJson);
 
-               MockRequest(Constants.fakeTemplateEmptyListResponseJson);
+            MockRequest(Constants.fakeTemplateEmptyListResponseJson);
 
             TemplateList templateList = client.GetAllTemplates();
 
@@ -488,7 +488,7 @@ namespace Notify.Tests.UnitTests
                     {"document", new JObject
                       {
                         {"file", "JVBERi0xLjUgdGVzdHBkZg=="},
-                        {"is_csv", false},
+                        {"filename", null},
                         {"confirm_email_before_download", null},
                         {"retention_period", null}
                       }
@@ -508,11 +508,11 @@ namespace Notify.Tests.UnitTests
         }
 
         [Test, Category("Unit"), Category("Unit/NotificationClient")]
-        public void SendEmailNotificationWithCSVDocumentGeneratesExpectedRequest()
+        public void SendEmailNotificationWithFilenameDocumentGeneratesExpectedRequest()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>
                 {
-                    { "document", NotificationClient.PrepareUpload(Encoding.UTF8.GetBytes("%PDF-1.5 testpdf"), true) }
+                    { "document", NotificationClient.PrepareUpload(Encoding.UTF8.GetBytes("%PDF-1.5 testpdf"), "report.csv") }
                 };
             JObject expected = new JObject
             {
@@ -523,7 +523,7 @@ namespace Notify.Tests.UnitTests
                     {"document", new JObject
                       {
                         {"file", "JVBERi0xLjUgdGVzdHBkZg=="},
-                        {"is_csv", true},
+                        {"filename", "report.csv"},
                         {"confirm_email_before_download", null},
                         {"retention_period", null}
                       }
@@ -546,7 +546,7 @@ namespace Notify.Tests.UnitTests
         public void PrepareUploadWithLargeDocumentGeneratesAnError()
         {
             Assert.That(
-                    () => { NotificationClient.PrepareUpload(new byte[3*1024*1024]); },
+                    () => { NotificationClient.PrepareUpload(new byte[3 * 1024 * 1024]); },
                     Throws.ArgumentException
                     );
         }
@@ -554,12 +554,12 @@ namespace Notify.Tests.UnitTests
         [Test, Category("Unit"), Category("Unit/NotificationClient")]
         public void PrepareUploadCanSetConfirmEmailBeforeDownloadAndRetentionPeriod()
         {
-            var fileData = new byte[1*1024*1024];
-            var actual = NotificationClient.PrepareUpload(fileData, false, false, "1 weeks");
+            var fileData = new byte[1 * 1024 * 1024];
+            var actual = NotificationClient.PrepareUpload(fileData, "report.csv", false, "1 weeks");
             var expected = new JObject
             {
                 {"file", System.Convert.ToBase64String(fileData)},
-                {"is_csv", false},
+                {"filename", "report.csv"},
                 {"confirm_email_before_download", false},
                 {"retention_period", "1 weeks"}
             };

--- a/src/GovukNotify/Client/NotificationClient.cs
+++ b/src/GovukNotify/Client/NotificationClient.cs
@@ -245,29 +245,46 @@ namespace Notify.Client
             return response;
         }
 
-        public static JObject PrepareUpload(byte[] documentContents, bool isCsv, bool confirmEmailBeforeDownload, string retentionPeriod)
+        public static JObject PrepareUpload(byte[] documentContents, string filename, bool confirmEmailBeforeDownload, string retentionPeriod)
         {
-            if (documentContents.Length > 2 * 1024 * 1024) {
+            if (documentContents.Length > 2 * 1024 * 1024)
+            {
                 throw new System.ArgumentException("File is larger than 2MB");
             }
             return new JObject
             {
                 {"file", System.Convert.ToBase64String(documentContents)},
-                {"is_csv", isCsv},
+                {"filename", filename},
                 {"confirm_email_before_download", confirmEmailBeforeDownload},
                 {"retention_period", retentionPeriod}
             };
         }
 
-        public static JObject PrepareUpload(byte[] documentContents, bool isCsv = false)
+        public static JObject PrepareUpload(byte[] documentContents, string filename)
         {
-            if (documentContents.Length > 2 * 1024 * 1024) {
+            if (documentContents.Length > 2 * 1024 * 1024)
+            {
                 throw new System.ArgumentException("File is larger than 2MB");
             }
             return new JObject
             {
                 {"file", System.Convert.ToBase64String(documentContents)},
-                {"is_csv", isCsv},
+                {"filename", filename},
+                {"confirm_email_before_download", null},
+                {"retention_period", null}
+            };
+        }
+
+        public static JObject PrepareUpload(byte[] documentContents)
+        {
+            if (documentContents.Length > 2 * 1024 * 1024)
+            {
+                throw new System.ArgumentException("File is larger than 2MB");
+            }
+            return new JObject
+            {
+                {"file", System.Convert.ToBase64String(documentContents)},
+                {"filename", null},
                 {"confirm_email_before_download", null},
                 {"retention_period", null}
             };

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;net6;net462</TargetFrameworks>
-    <Version>6.1.0</Version>
+    <Version>7.0.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Update client for the new document download feature which allows specifying a download filename for files sent by email.

This supercedes the old `isCsv` parameter that was inconsistent at best.

Given this, we are dropping support for `isCsv` altogether.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [ ] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
