### PR TITLE
Update the API Key for nuget/appveyor.

### DIFF
--- a/appveyor.txt
+++ b/appveyor.txt
@@ -27,7 +27,7 @@ environment:
   SMS_SENDER_ID:
     secure: /e26eqAWnfu9m/ysZdTsYaP3ySpsuLaoABQXHHB+M+0Q39OkOxWp7UJ1T5+OAwFP
   NUGET_API_KEY:
-    secure: pdTFB380I1f6886ekz3rJLkqW+/zETcltPg3xdhTQ24SPMdknU81dvk4nQK8pP+i
+    secure: VeHOxqEjmjckDRnVP/tMmGoYFogKRgmkV2DMsf7YTZcot4C0l8d3GFIXQ66W06Ri
   pullId: 0
 build: off
 image: Visual Studio 2022


### PR DESCRIPTION
This expires automatically every 365 days. Corresponding update in `notifications-credentials`.

When updating this value, encrypt the value at
https://ci.appveyor.com/tools/encrypt before adding it to that file.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_net.md)
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
