### PR TITLE
chore: include new notification fields (cost_in_pounds, is_data_ready and cost_details)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [7.2.0] - 2024-07-31
+* Added fields related to cost data in response:
+  * `is_cost_data_ready`: This field is true if cost data is ready, and false if it isn't (Boolean).
+  * `cost_in_pounds`: Cost of the notification in pounds. The cost does not take free allowance into account (Float).
+  * `cost_details.billable_sms_fragments`: Number of billable SMS fragments in your text message (SMS only) (Integer).
+  * `cost_details.international_rate_multiplier`: For international SMS rate is multiplied by this value (SMS only) (Integer).
+  * `cost_details.sms_rate`: Cost of 1 SMS fragment (SMS only) (Float).
+  * `cost_details.billable_sheets_of_paper`: Number of sheets of paper in the letter you sent, that you will be charged for (letter only) (Integer).
+  * `cost_details.postage`: Postage class of the notification sent (letter only) (String).
+
 ## [7.1.0] - 2023-12-27
 
 * Adds `oneClickUnsubscribeURL` parameter to `SendEmailNotification`

--- a/src/GovukNotify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
+++ b/src/GovukNotify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
@@ -85,6 +85,10 @@ namespace Notify.Tests.IntegrationTests
             Assert.IsNotNull(notification.reference);
             Assert.AreEqual(notification.reference, "sample-test-ref");
 
+            Assert.IsNotNull(notification.costDetails.smsRate);
+            Assert.IsNotNull(notification.costDetails.billableSmsFragments);
+            Assert.IsNotNull(notification.costDetails.internationalRateMultiplier);
+
             NotifyAssertions.AssertNotification(notification);
         }
 
@@ -118,6 +122,12 @@ namespace Notify.Tests.IntegrationTests
             Assert.AreEqual(notification.body, TEST_EMAIL_BODY);
             Assert.IsNotNull(notification.subject);
             Assert.AreEqual(notification.subject, TEST_EMAIL_SUBJECT);
+
+            Assert.IsNull(notification.costDetails.smsRate);
+            Assert.IsNull(notification.costDetails.billableSmsFragments);
+            Assert.IsNull(notification.costDetails.internationalRateMultiplier);
+            Assert.IsNull(notification.costDetails.postage);
+            Assert.IsNull(notification.costDetails.billableSheetsOfPaper);
 
             NotifyAssertions.AssertNotification(notification);
         }
@@ -159,6 +169,9 @@ namespace Notify.Tests.IntegrationTests
 
             Assert.IsNotNull(notification.subject);
             Assert.AreEqual(notification.subject, TEST_LETTER_SUBJECT);
+
+            Assert.IsNotNull(notification.costDetails.postage);
+            Assert.IsNotNull(notification.costDetails.billableSheetsOfPaper);
 
             NotifyAssertions.AssertNotification(notification);
         }

--- a/src/GovukNotify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
+++ b/src/GovukNotify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
@@ -88,6 +88,10 @@ namespace Notify.Tests.IntegrationTests
             Assert.IsNotNull(notification.reference);
             Assert.AreEqual(notification.reference, "sample-test-ref");
 
+            Assert.IsNotNull(notification.costDetails.smsRate);
+            Assert.IsNotNull(notification.costDetails.billableSmsFragments);
+            Assert.IsNotNull(notification.costDetails.internationalRateMultiplier);
+
             NotifyAssertions.AssertNotification(notification);
         }
 
@@ -121,6 +125,12 @@ namespace Notify.Tests.IntegrationTests
             Assert.AreEqual(notification.body, TEST_EMAIL_BODY);
             Assert.IsNotNull(notification.subject);
             Assert.AreEqual(notification.subject, TEST_EMAIL_SUBJECT);
+
+            Assert.IsNull(notification.costDetails.smsRate);
+            Assert.IsNull(notification.costDetails.billableSmsFragments);
+            Assert.IsNull(notification.costDetails.internationalRateMultiplier);
+            Assert.IsNull(notification.costDetails.postage);
+            Assert.IsNull(notification.costDetails.billableSheetsOfPaper);
 
             NotifyAssertions.AssertNotification(notification);
         }
@@ -162,6 +172,9 @@ namespace Notify.Tests.IntegrationTests
 
             Assert.IsNotNull(notification.subject);
             Assert.AreEqual(notification.subject, TEST_LETTER_SUBJECT);
+
+            Assert.IsNotNull(notification.costDetails.postage);
+            Assert.IsNotNull(notification.costDetails.billableSheetsOfPaper);
 
             NotifyAssertions.AssertNotification(notification);
         }

--- a/src/GovukNotify.Tests/UnitTests/Constants.cs
+++ b/src/GovukNotify.Tests/UnitTests/Constants.cs
@@ -49,6 +49,13 @@ namespace Notify.Tests.UnitTests
                                 ""version"": 2  },
                             ""type"": ""sms"",
                             ""one_click_unsubscribe_url"": null,
+                            ""is_cost_data_ready"": true,
+                            ""cost_in_pounds"": 0.5,
+                            ""cost_details"": {
+                                ""billable_sms_fragments"": 1,
+                                ""international_rate_multiplier"": 0.05,
+                                ""sms_rate"": 0.5
+                            }
                         }";
             }
         }
@@ -83,6 +90,13 @@ namespace Notify.Tests.UnitTests
                                 ""version"": 2  },
                             ""type"": ""sms"",
                             ""one_click_unsubscribe_url"": null,
+                            ""is_cost_data_ready"": true,
+                            ""cost_in_pounds"": 0.5,
+                            ""cost_details"": {
+                                ""billable_sms_fragments"": 1,
+                                ""international_rate_multiplier"": 0.05,
+                                ""sms_rate"": 0.5
+                            }
                         },
                         {
                             ""completed_at"": null,
@@ -108,6 +122,9 @@ namespace Notify.Tests.UnitTests
                                 ""version"": 2  },
                             ""type"": ""email"",
                             ""one_click_unsubscribe_url"": ""https://www.example.com/unsubscribe"",
+                            ""is_cost_data_ready"": true,
+                            ""cost_in_pounds"": 0.5,
+                            ""cost_details"": {}
                         }
                     ]
                 }";
@@ -143,6 +160,13 @@ namespace Notify.Tests.UnitTests
                                 ""version"": 2  },
                             ""type"": ""sms"",
                             ""one_click_unsubscribe_url"": null,
+                            ""is_cost_data_ready"": true,
+                            ""cost_in_pounds"": 0.5,
+                            ""cost_details"": {
+                                ""billable_sms_fragments"": 1,
+                                ""international_rate_multiplier"": 0.05,
+                                ""sms_rate"": 0.5
+                            }
                         },
                         {
                             ""completed_at"": null,
@@ -168,6 +192,13 @@ namespace Notify.Tests.UnitTests
                                 ""version"": 2  },
                             ""type"": ""sms"",
                             ""one_click_unsubscribe_url"": null,
+                            ""is_cost_data_ready"": true,
+                            ""cost_in_pounds"": 0.5,
+                            ""cost_details"": {
+                                ""billable_sms_fragments"": 1,
+                                ""international_rate_multiplier"": 0.05,
+                                ""sms_rate"": 0.5
+                            }
                         }
                     ]
                 }";
@@ -204,6 +235,9 @@ namespace Notify.Tests.UnitTests
                                 ""version"": 2  },
                             ""type"": ""email"",
                             ""one_click_unsubscribe_url"": ""https://www.example.com/unsubscribe"",
+                            ""is_cost_data_ready"": true,
+                            ""cost_in_pounds"": 0.0,
+                            ""cost_details"": {}
                         },
                         {
                             ""completed_at"": null,
@@ -229,6 +263,9 @@ namespace Notify.Tests.UnitTests
                                 ""version"": 2  },
                             ""type"": ""email"",
                             ""one_click_unsubscribe_url"": ""https://www.example.com/unsubscribe"",
+                            ""is_cost_data_ready"": true,
+                            ""cost_in_pounds"": 0.0,
+                            ""cost_details"": {}
                         }
                     ]
                 }";
@@ -264,6 +301,12 @@ namespace Notify.Tests.UnitTests
                                 ""version"": 2  },
                             ""type"": ""letter"",
                             ""one_click_unsubscribe_url"": null,
+                            ""is_cost_data_ready"": true,
+                            ""cost_in_pounds"": 0.5,
+                            ""cost_details"": {
+                                ""billable_sheets_of_paper"": 1,
+                                ""postage"": ""first""
+                            }
                         },
                         {
                             ""completed_at"": null,
@@ -289,6 +332,12 @@ namespace Notify.Tests.UnitTests
                                 ""version"": 2  },
                             ""type"": ""letter"",
                             ""one_click_unsubscribe_url"": null,
+                            ""is_cost_data_ready"": true,
+                            ""cost_in_pounds"": 0.5,
+                            ""cost_details"": {
+                                ""billable_sheets_of_paper"": 1,
+                                ""postage"": ""first""
+                            }
                         }
                     ]
                 }";

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;net6;net462</TargetFrameworks>
-    <Version>7.1.0</Version>
+    <Version>7.2.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/GovukNotify/Models/CostDetails.cs
+++ b/src/GovukNotify/Models/CostDetails.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Newtonsoft.Json;
 
 namespace Notify.Models

--- a/src/GovukNotify/Models/CostDetails.cs
+++ b/src/GovukNotify/Models/CostDetails.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Newtonsoft.Json;
 
 namespace Notify.Models
@@ -7,18 +5,18 @@ namespace Notify.Models
     public class CostDetails
     {
         [JsonProperty("billable_sms_fragments")]
-        public int? billableSmsFragments;
+        public int? billableSmsFragments { get; set; }
 
         [JsonProperty("international_rate_multiplier")]
-        public double? internationalRateMultiplier;
+        public double? internationalRateMultiplier { get; set; }
 
         [JsonProperty("sms_rate")]
-        public double? smsRate;
+        public double? smsRate { get; set; }
 
         [JsonProperty("billable_sheets_of_paper")]
-        public int? billableSheetsOfPaper;
+        public int? billableSheetsOfPaper { get; set; }
 
-        public string? postage;
+        public string postage { get; set; }
 
         public override bool Equals(object costDetail)
         {

--- a/src/GovukNotify/Models/CostDetails.cs
+++ b/src/GovukNotify/Models/CostDetails.cs
@@ -1,0 +1,40 @@
+using Newtonsoft.Json;
+
+namespace Notify.Models
+{
+    public class CostDetails
+    {
+        [JsonProperty("billable_sms_fragments")]
+        public int? billableSmsFragments;
+
+        [JsonProperty("international_rate_multiplier")]
+        public double? internationalRateMultiplier;
+
+        [JsonProperty("sms_rate")]
+        public double? smsRate;
+
+        [JsonProperty("billable_sheets_of_paper")]
+        public int? billableSheetsOfPaper;
+
+        public string? postage;
+
+        public override bool Equals(object costDetail)
+        {
+            if (!(costDetail is CostDetails cd))
+            {
+                return false;
+            }
+
+            return billableSmsFragments == cd.billableSmsFragments &&
+                   internationalRateMultiplier == cd.internationalRateMultiplier &&
+                   smsRate == cd.smsRate &&
+                   billableSheetsOfPaper == cd.billableSheetsOfPaper &&
+                   postage == cd.postage;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/src/GovukNotify/Models/Notification.cs
+++ b/src/GovukNotify/Models/Notification.cs
@@ -39,6 +39,12 @@ namespace Notify.Models
         public string type;
         [JsonProperty("created_by_name")]
         public string createdByName;
+        [JsonProperty("is_cost_data_ready")]
+        public bool isCostDataReady;
+        [JsonProperty("cost_in_pounds")]
+        public double? costInPounds;
+        [JsonProperty("cost_details")]
+        public CostDetails costDetails;
 
 
         public override bool Equals(object notification)
@@ -70,7 +76,14 @@ namespace Notify.Models
                 template.version == note.template.version &&
                 type == note.type &&
                 createdByName == note.createdByName &&
-                oneClickUnsubscribeURL == note.oneClickUnsubscribeURL;
+                oneClickUnsubscribeURL == note.oneClickUnsubscribeURL &&
+                isCostDataReady == note.isCostDataReady &&
+                costInPounds == note.costInPounds &&
+                costDetails.billableSmsFragments == note.costDetails.billableSmsFragments &&
+                costDetails.internationalRateMultiplier == note.costDetails.internationalRateMultiplier &&
+                costDetails.smsRate == note.costDetails.smsRate &&
+                costDetails.billableSheetsOfPaper == note.costDetails.billableSheetsOfPaper &&
+                costDetails.postage == note.costDetails.postage;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
New fields have been added to the response of `get_notification(notificationId)` endpoint
- cost_in_pounds
- is_cost_data_ready
- cost_details:
-- **Nested fields for letters**:
--- billable_sheets_of_paper
--- postage
-- **Nested fields for sms**:
--- billable_sms_fragments
--- international_rate_multiplier
--- sms_rate
 
Based on the addition this PR updates our client documentation to showcase an aligned response for the endpoint

### Related task : 
[3. Add GET notification cost data to API clients and API client docs](https://trello.com/c/5VZrBNpU/845-3-add-get-notification-cost-data-to-api-clients-and-api-client-docs)

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [x] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_net.md)
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
