### PR TITLE
Update integration tests to wait before checking SMS cost data

### DIFF
--- a/src/GovukNotify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
+++ b/src/GovukNotify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
@@ -75,6 +75,19 @@ namespace Notify.Tests.IntegrationTests
             await SendSmsTestWithPersonalisation();
             Notification notification = await this.client.GetNotificationByIdAsync(this.smsNotificationId);
 
+            for (int i = 0; i < 15; i++)
+            {
+                if (notification.isCostDataReady)
+                {
+                    break;
+                }
+                else
+                {
+                    await Task.Delay(3000);
+                    notification = await this.client.GetNotificationByIdAsync(this.smsNotificationId);
+                }
+            }
+
             Assert.IsNotNull(notification);
             Assert.IsNotNull(notification.id);
             Assert.AreEqual(notification.id, this.smsNotificationId);

--- a/src/GovukNotify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
+++ b/src/GovukNotify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
@@ -78,6 +78,19 @@ namespace Notify.Tests.IntegrationTests
             SendSmsTestWithPersonalisation();
             Notification notification = this.client.GetNotificationById(this.smsNotificationId);
 
+            for (int i = 0; i < 15; i++)
+            {
+                if (notification.isCostDataReady)
+                {
+                    break;
+                }
+                else
+                {
+                    Thread.Sleep(3000);
+                    notification = this.client.GetNotificationById(this.smsNotificationId);
+                }
+            }
+
             Assert.IsNotNull(notification);
             Assert.IsNotNull(notification.id);
             Assert.AreEqual(notification.id, this.smsNotificationId);


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
The tests which check if the `costDetails` properties for an SMS notification are not null have been failing at times because those fields are null. Those properties aren't ready immediately, but we can check if they are by checking whether `isCostDataReady` is true and adding in a wait if the cost data is not ready yet.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_net.md)
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
