### PR TITLE
Dockerfile: Install awscli & copy repo into workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ RUN \
     echo "Install base packages" \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+    awscli \
     gnupg \
     make \
     jq
 
 WORKDIR /var/project
+COPY . .


### PR DESCRIPTION
In the new deploy pipeline, the AWS cli will be used to fetch the SSM parameter containing the environment variables required to run the integration tests.

We also copy the repo into the built image so that we don't need to _also_ back the repo into the deployment bag.