### PR TITLE
Update the dependencies and add support for later versions of .NET

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,14 @@ RUN \
     echo "Install base packages" \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+    unzip \
     gnupg \
     make \
     jq
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install
 
 WORKDIR /var/project
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0
 
 RUN \
     echo "Install base packages" \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    awscli \
     gnupg \
     make \
     jq

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 
 .PHONY: build
 build: ## Build project
-	dotnet build -f=net6
+	dotnet build -f=net10.0
 
 .PHONY: format
 format:
@@ -22,15 +22,15 @@ test: single-test
 
 .PHONY: single-test
 single-test: build ## run a single test. usage: "make single-test test=[test name]"
-	dotnet test ./src/GovukNotify.Tests/GovukNotify.Tests.csproj -f=net6 --no-build -v=n --filter $(test)
+	dotnet test ./src/GovukNotify.Tests/GovukNotify.Tests.csproj -f=net10.0 --no-build -v=n --filter $(test)
 
 .PHONY: build-release
 build-release: ## Build release version
-	dotnet build -c=Release -f=net6
+	dotnet build -c=Release -f=net10.0
 
 .PHONY: build-package
 build-package: build-release ## Build and package NuGet
-	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj /p:TargetFrameworks=net6 -o=publish
+	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj /p:TargetFrameworks=net8,net9,net10 -o=publish
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker:  ## Prepare the Docker builder image

--- a/src/GovukNotify.Tests/GovukNotify.Tests.csproj
+++ b/src/GovukNotify.Tests/GovukNotify.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net462</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net6;net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/GovukNotify.Tests/GovukNotify.Tests.csproj
+++ b/src/GovukNotify.Tests/GovukNotify.Tests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GovukNotify.Tests/GovukNotify.Tests.csproj
+++ b/src/GovukNotify.Tests/GovukNotify.Tests.csproj
@@ -11,8 +11,10 @@
     <PackageReference Include="Moq" Version="4.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GovukNotify.Tests/GovukNotify.Tests.csproj
+++ b/src/GovukNotify.Tests/GovukNotify.Tests.csproj
@@ -1,19 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net6;net462</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GovukNotify.Tests/IntegrationTests/Assertions.cs
+++ b/src/GovukNotify.Tests/IntegrationTests/Assertions.cs
@@ -12,7 +12,7 @@ namespace Notify.Tests.IntegrationTests
             Assert.IsNotNull(notification.type);
             String notificationType = notification.type;
             String[] allowedNotificationTypes = { "email", "sms", "letter" };
-            CollectionAssert.Contains(allowedNotificationTypes, notificationType);
+            Assert.That(allowedNotificationTypes, Does.Contain(notificationType));
             if (notificationType.Equals("sms"))
             {
                 Assert.IsNotNull(notification.phoneNumber);
@@ -45,7 +45,7 @@ namespace Notify.Tests.IntegrationTests
                 "virus-scan-failed",
                 "validation-failed"
             };
-            CollectionAssert.Contains(allowedStatusTypes, notificationStatus);
+            Assert.That(allowedStatusTypes, Does.Contain(notificationStatus));
 
             if (notificationStatus.Equals("delivered"))
             {

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <TargetFrameworks>net10.0;net9.0;netstandard2.0;net6;net462</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Version>7.2.1</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
@@ -16,11 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JWT" Version="[7.1,9)" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="JWT" Version="[11,12]" />
+    <PackageReference Include="Newtonsoft.Json" Version="[13.0.4,14]" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>net10.0</TargetFrameworks>
-    <Version>7.2.1</Version>
+    <Version>8.0.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <TargetFrameworks>netstandard2.0;net6;net462</TargetFrameworks>
-    <Version>7.2.0</Version>
+    <TargetFrameworks>net10.0;net9.0;netstandard2.0;net6;net462</TargetFrameworks>
+    <Version>7.2.1</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="JWT" Version="[7.1,9)" />
-    <PackageReference Include="Newtonsoft.Json" Version="[10.0.3,14)" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->
The Gov.Notify client is reporting has having vulnerable dependencies and this PR looks to make the minimum changes required to remove this issue. It also looks to upgrade support for modern .NET versions so that it will be published as targeting .NET 9 and 10 whilst maintaining the support for the previous older versions. 

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_net.md)
  - [ ] `CHANGELOG.md`
- [x] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)

We have run the unit tests locally. 

Fixes #195