### PR TITLE
Remove .NET 8 and 9 from build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build-release: ## Build release version
 
 .PHONY: build-package
 build-package: build-release ## Build and package NuGet
-	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj /p:TargetFrameworks=net8,net9,net10 -o=publish
+	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj /p:TargetFrameworks=net10.0 -o=publish
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker:  ## Prepare the Docker builder image


### PR DESCRIPTION
We’ve dropped support for these versions. Accidentally left them in this command; they aren’t present in other make commands

Also .NET 10 is specified by `net10.0` not `net10`

***

Successfully run locally:

<img width="812" height="387" alt="image" src="https://github.com/user-attachments/assets/ab051c6b-2f97-4df0-84f1-005199e4f300" />
