### PR TITLE
Restore compatibility with .NET 9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## [8.0.0] - 2026-03-19
+## [9.0.0] - 2026-03-20
+
+* Restore support for .NET Core version 9.0 (supported versions are now 9.0 and 10.0)
+
+## [8.0.0] - (unreleased)
 
 * Updates versions of JWT and Newtonsoft.JSON dependencies
 * Drops support for .NET Core version 9.0 or earlier
-* Drops support for .NET Framework 
+* Drops support for .NET Framework
 
 ## [7.2.0] - 2024-07-31
 * Added fields related to cost data in response:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [8.0.0] - 2026-03-19
+
+* Updates versions of JWT and Newtonsoft.JSON dependencies
+* Drops support for .NET Core version 9.0 or earlier
+* Drops support for .NET Framework 
+
 ## [7.2.0] - 2024-07-31
 * Added fields related to cost data in response:
   * `is_cost_data_ready`: This field is true if cost data is ready, and false if it isn't (Boolean).

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 
 .PHONY: build
 build: ## Build project
-	dotnet build -f=net10.0
+	dotnet build
 
 .PHONY: format
 format:
@@ -22,15 +22,15 @@ test: single-test
 
 .PHONY: single-test
 single-test: build ## run a single test. usage: "make single-test test=[test name]"
-	dotnet test ./src/GovukNotify.Tests/GovukNotify.Tests.csproj -f=net10.0 --no-build -v=n --filter $(test)
+	dotnet test ./src/GovukNotify.Tests/GovukNotify.Tests.csproj --no-build -v=n --filter $(test)
 
 .PHONY: build-release
 build-release: ## Build release version
-	dotnet build -c=Release -f=net10.0
+	dotnet build -c=Release
 
 .PHONY: build-package
 build-package: build-release ## Build and package NuGet
-	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj /p:TargetFrameworks=net8,net9,net10 -o=publish
+	dotnet pack -c=Release ./src/GovukNotify/GovukNotify.csproj -o=publish
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker:  ## Prepare the Docker builder image

--- a/appveyor.txt
+++ b/appveyor.txt
@@ -1,3 +1,7 @@
+install:
+- ps: |
+    Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
+    & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '10.0.100' -InstallDir "$env:ProgramFiles\dotnet"
 clone_script:
 - cmd: >-
     git clone -q --branch=main https://github.com/alphagov/notifications-net-client.git C:\projects\notifications-net-client
@@ -31,6 +35,8 @@ environment:
   pullId: 0
 build: off
 image: Visual Studio 2022
+before_test:
+  - cmd: dotnet --version
 test_script: dotnet test C:\projects\notifications-net-client\src\GovukNotify.Tests -c=Release
 on_success:
 - publish.cmd

--- a/src/GovukNotify.Tests/GovukNotify.Tests.csproj
+++ b/src/GovukNotify.Tests/GovukNotify.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
-
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <LangVersion>14.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
-    <Version>8.0.0</Version>
+    <Version>9.0.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
     <Version>8.0.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
@@ -18,10 +18,6 @@
   <ItemGroup>
     <PackageReference Include="JWT" Version="[11,12]" />
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.4,14]" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Since appveyor doesn’t have .NET 10 we need to also publish for .NET 9

This commit makes sure we are building and testing against both everywhere. To make this simpler I have removed the flags from the `Makefile` and let the target versions be defined canonically in the `*.csproj` files.

The only change to make .NET 9.0 work was specifying `<LangVersion>14.0</LangVersion>` when building the tests. .NET 9.0 uses CSharp version 13.0, which is missing some of the assertion features we need in the tests (probably since dropping NUnit). But I think this should be fine because Appveyor will be using the packaged code, not compiling it from source.