### PR TITLE
Update location of credentials needed for integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ make bootstrap-with-docker
 In the root directory of the repo, run:
 
 ```
-notify-pass credentials/client-integration-tests > environment.sh
+notify-pass credentials/staging/ssm/api_client_integration_tests_environment > environment.sh
 ```
 
 Unless you're part of the GOV.UK Notify team, you won't be able to run this command or the Integration Tests. However, the file still needs to exist - run `touch environment.sh` instead.


### PR DESCRIPTION
The guidance was out of date.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_net.md)
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
