### PR TITLE
Allow users to sanitise personalisation when sending emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [8.1.0] - 2026-06-03
+* Adds `sanitiseContentFor` parameter to `sendEmail` enpdpoint. 
+* Adds `sanitisedContent` field to the response object for `sendEmail` enpdpoint.
+
+See [our documentation](https://docs.notifications.service.gov.uk/net.html#reducing-the-risk-of-malicious-content-injection-in-placeholders) for guidance on how to use this.
+
 ## [8.0.0] - 2026-03-19
 
 * Updates versions of JWT and Newtonsoft.JSON dependencies

--- a/src/GovukNotify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
+++ b/src/GovukNotify.Tests/IntegrationTests/NotificationClientAsyncIntegrationTests.cs
@@ -475,8 +475,9 @@ namespace Notify.Tests.IntegrationTests
         {
             Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
             {
-                { "name", "someone" }
+                { "name", "Anna, [click here](https://evil.link)" }
             };
+            List<string> sanitiseContentFor = new List<string> {"name"};
 
             EmailNotificationResponse response = await this.client.SendEmailAsync(
                 FUNCTIONAL_TEST_EMAIL,
@@ -484,14 +485,17 @@ namespace Notify.Tests.IntegrationTests
                 personalisation,
                 clientReference: "TestReference",
                 emailReplyToId: EMAIL_REPLY_TO_ID,
-                oneClickUnsubscribeURL: "https://www.example.com/unsubscribe"
+                oneClickUnsubscribeURL: "https://www.example.com/unsubscribe",
+                sanitiseContentFor: sanitiseContentFor
             );
             this.emailNotificationId = response.id;
             Assert.IsNotNull(response);
-            Assert.AreEqual(response.content.body, TEST_EMAIL_BODY);
+            Assert.AreEqual(response.content.body, "Hello Anna, \\[click here\\]\\(\\)\r\n\r\nFunctional test help make our world a better place");
             Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
             Assert.AreEqual(response.reference, "TestReference");
             Assert.AreEqual(response.content.oneClickUnsubscribeURL, "https://www.example.com/unsubscribe");
+            Assert.AreEqual(response.sanitisedContent["name"]["unsanitised"], "Anna, [click here](https://evil.link)");
+            Assert.AreEqual(response.sanitisedContent["name"]["sanitised"], "Anna, \\[click here\\]\\(\\)");
         }
 
         [Test, Category("Integration"), Category("Integration/NotificationClientAsync")]

--- a/src/GovukNotify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
+++ b/src/GovukNotify.Tests/IntegrationTests/NotificationClientIntegrationTests.cs
@@ -486,8 +486,9 @@ namespace Notify.Tests.IntegrationTests
         {
             Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
             {
-                { "name", "someone" }
+                { "name", "Anna, [click here](https://evil.link)" }
             };
+            List<string> sanitiseContentFor = new List<string> {"name"};
 
             EmailNotificationResponse response = this.client.SendEmail(
                 FUNCTIONAL_TEST_EMAIL,
@@ -495,14 +496,17 @@ namespace Notify.Tests.IntegrationTests
                 personalisation,
                 clientReference: "TestReference",
                 emailReplyToId: EMAIL_REPLY_TO_ID,
-                oneClickUnsubscribeURL: "https://www.example.com/unsubscribe"
+                oneClickUnsubscribeURL: "https://www.example.com/unsubscribe",
+                sanitiseContentFor: sanitiseContentFor
             );
             this.emailNotificationId = response.id;
             Assert.IsNotNull(response);
-            Assert.AreEqual(response.content.body, TEST_EMAIL_BODY);
+            Assert.AreEqual(response.content.body, "Hello Anna, \\[click here\\]\\(\\)\r\n\r\nFunctional test help make our world a better place");
             Assert.AreEqual(response.content.subject, TEST_EMAIL_SUBJECT);
             Assert.AreEqual(response.reference, "TestReference");
             Assert.AreEqual(response.content.oneClickUnsubscribeURL, "https://www.example.com/unsubscribe");
+            Assert.AreEqual(response.sanitisedContent["name"]["unsanitised"], "Anna, [click here](https://evil.link)");
+            Assert.AreEqual(response.sanitisedContent["name"]["sanitised"], "Anna, \\[click here\\]\\(\\)");
         }
 
         [Test, Category("Integration"), Category("Integration/NotificationClient")]

--- a/src/GovukNotify.Tests/UnitTests/Constants.cs
+++ b/src/GovukNotify.Tests/UnitTests/Constants.cs
@@ -520,6 +520,7 @@ namespace Notify.Tests.UnitTests
                                 ""from_email"": ""someone@mail.com"",
                                 ""subject"": ""Test"",
                                 ""one_click_unsubscribe_url"": ""https://www.example.com/unsubscribe"",
+                                ""sanitisedContent"": {}
                             },
                             ""id"": ""731b9c83-563f-4b59-afc5-87e9ca717833"",
                             ""reference"":  ""some-client-ref"",

--- a/src/GovukNotify.Tests/UnitTests/NotificationClientAsyncUnitTests.cs
+++ b/src/GovukNotify.Tests/UnitTests/NotificationClientAsyncUnitTests.cs
@@ -575,6 +575,39 @@ namespace Notify.Tests.UnitTests
         }
 
         [Test, Category("Unit"), Category("Unit/NotificationClientAsync")]
+        public async Task SendEmailNotificationWithSanitiseContentForGeneratesExpectedRequest()
+        {
+            var personalisation = new Dictionary<string, dynamic>
+                {
+                    { "name", "someone" }
+                };
+            var sanitiseContentFor = new List<string> {"name"};
+            var expected = new JObject
+            {
+                { "email_address", Constants.fakeEmail },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", JObject.FromObject(personalisation) },
+                { new JProperty("sanitise_content_for", sanitiseContentFor) },
+            };
+
+            MockRequest(
+                Constants.fakeEmailNotificationResponseJson,
+                client.SEND_EMAIL_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent,
+                expected.ToString(Formatting.None)
+            );
+
+            await client.SendEmailAsync(
+                Constants.fakeEmail,
+                Constants.fakeTemplateId,
+                personalisation,
+                sanitiseContentFor: sanitiseContentFor
+            );
+        }
+
+        [Test, Category("Unit"), Category("Unit/NotificationClientAsync")]
         public async Task SendEmailNotificationWithDocumentGeneratesExpectedRequest()
         {
             Dictionary<string, dynamic> personalisation = new Dictionary<string, dynamic>

--- a/src/GovukNotify.Tests/UnitTests/NotificationClientUnitTests.cs
+++ b/src/GovukNotify.Tests/UnitTests/NotificationClientUnitTests.cs
@@ -585,6 +585,34 @@ namespace Notify.Tests.UnitTests
             client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, oneClickUnsubscribeURL: Constants.fakeoneClickUnsubscribeURL);
         }
 
+        [Test, Category("Unit"), Category("Unit/NotificationClientAsync")]
+        public void SendEmailNotificationWithSanitiseContentForGeneratesExpectedRequest()
+        {
+            var personalisation = new Dictionary<string, dynamic>
+                {
+                    { "name", "someone" }
+                };
+            var sanitiseContentFor = new List<string> {"name"};
+            var expected = new JObject
+            {
+                { "email_address", Constants.fakeEmail },
+                { "template_id", Constants.fakeTemplateId },
+                { "personalisation", JObject.FromObject(personalisation) },
+                { new JProperty("sanitise_content_for", sanitiseContentFor) },
+            };
+
+            MockRequest(
+                Constants.fakeEmailNotificationResponseJson,
+                client.SEND_EMAIL_NOTIFICATION_URL,
+                AssertValidRequest,
+                HttpMethod.Post,
+                AssertGetExpectedContent,
+                expected.ToString(Formatting.None)
+            );
+
+            client.SendEmail(Constants.fakeEmail, Constants.fakeTemplateId, personalisation, sanitiseContentFor: sanitiseContentFor);
+        }
+
         [Test, Category("Unit"), Category("Unit/NotificationClient")]
         public void SendEmailNotificationWithDocumentGeneratesExpectedRequest()
         {

--- a/src/GovukNotify/Client/NotificationClient.cs
+++ b/src/GovukNotify/Client/NotificationClient.cs
@@ -154,9 +154,15 @@ namespace Notify.Client
             return JsonConvert.DeserializeObject<SmsNotificationResponse>(response);
         }
 
-        public async Task<EmailNotificationResponse> SendEmailAsync(string emailAddress, string templateId,
-            Dictionary<string, dynamic> personalisation = null, string clientReference = null,
-            string emailReplyToId = null, string oneClickUnsubscribeURL = null)
+        public async Task<EmailNotificationResponse> SendEmailAsync(
+            string emailAddress,
+            string templateId,
+            Dictionary<string, dynamic> personalisation = null,
+            string clientReference = null,
+            string emailReplyToId = null,
+            string oneClickUnsubscribeURL = null,
+            List<string> sanitiseContentFor = null
+        )
         {
             var o = CreateRequestParams(templateId, personalisation, clientReference);
             o.AddFirst(new JProperty("email_address", emailAddress));
@@ -169,6 +175,11 @@ namespace Notify.Client
             if (oneClickUnsubscribeURL != null)
             {
                 o.Add(new JProperty("one_click_unsubscribe_url", oneClickUnsubscribeURL));
+            }
+
+            if (sanitiseContentFor != null)
+            {
+                o.Add(new JProperty("sanitise_content_for", sanitiseContentFor));
             }
 
             var response = await POST(SEND_EMAIL_NOTIFICATION_URL, o.ToString(Formatting.None)).ConfigureAwait(false);
@@ -447,11 +458,19 @@ namespace Notify.Client
             }
         }
 
-        public EmailNotificationResponse SendEmail(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string emailReplyToId = null, string oneClickUnsubscribeURL = null)
+        public EmailNotificationResponse SendEmail(
+            string emailAddress,
+            string templateId,
+            Dictionary<string, dynamic> personalisation = null,
+            string clientReference = null,
+            string emailReplyToId = null,
+            string oneClickUnsubscribeURL = null,
+            List<string> sanitiseContentFor = null
+        )
         {
             try
             {
-                return SendEmailAsync(emailAddress, templateId, personalisation, clientReference, emailReplyToId, oneClickUnsubscribeURL).Result;
+                return SendEmailAsync(emailAddress, templateId, personalisation, clientReference, emailReplyToId, oneClickUnsubscribeURL, sanitiseContentFor).Result;
             }
             catch (AggregateException ex)
             {

--- a/src/GovukNotify/GovukNotify.csproj
+++ b/src/GovukNotify/GovukNotify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>net10.0</TargetFrameworks>
-    <Version>8.0.0</Version>
+    <Version>8.1.0</Version>
     <Authors>GOV.UK Notify</Authors>
     <Description>GOV.UK .NET Notify Client</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/GovukNotify/Interfaces/IAsyncNotificationClient.cs
+++ b/src/GovukNotify/Interfaces/IAsyncNotificationClient.cs
@@ -23,7 +23,15 @@ namespace Notify.Interfaces
 
         Task<SmsNotificationResponse> SendSmsAsync(string mobileNumber, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string smsSenderId = null);
 
-        Task<EmailNotificationResponse> SendEmailAsync(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string emailReplyToId = null, string oneClickUnsubscribeURL = null);
+        Task<EmailNotificationResponse> SendEmailAsync(
+            string emailAddress,
+            string templateId,
+            Dictionary<string, dynamic> personalisation = null,
+            string clientReference = null,
+            string emailReplyToId = null,
+            string oneClickUnsubscribeURL = null,
+            List<string> sanitiseContentFor = null
+        );
 
         Task<LetterNotificationResponse> SendLetterAsync(string templateId, Dictionary<string, dynamic> personalisation, string clientReference = null);
 

--- a/src/GovukNotify/Interfaces/INotificationClient.cs
+++ b/src/GovukNotify/Interfaces/INotificationClient.cs
@@ -22,7 +22,15 @@ namespace Notify.Interfaces
 
         SmsNotificationResponse SendSms(string mobileNumber, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string smsSenderId = null);
 
-        EmailNotificationResponse SendEmail(string emailAddress, string templateId, Dictionary<string, dynamic> personalisation = null, string clientReference = null, string emailReplyToId = null, string oneClickUnsubscribeURL = null);
+        EmailNotificationResponse SendEmail(
+            string emailAddress,
+            string templateId,
+            Dictionary<string, dynamic> personalisation = null,
+            string clientReference = null,
+            string emailReplyToId = null,
+            string oneClickUnsubscribeURL = null,
+            List<string> sanitiseContentFor = null
+        );
 
         LetterNotificationResponse SendLetter(string templateId, Dictionary<string, dynamic> personalisation, string clientReference = null);
 

--- a/src/GovukNotify/Models/Responses/EmailNotificationResponse.cs
+++ b/src/GovukNotify/Models/Responses/EmailNotificationResponse.cs
@@ -1,10 +1,14 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Notify.Models.Responses
 {
     public class EmailNotificationResponse : NotificationResponse
     {
         public EmailResponseContent content;
+
+        [JsonProperty("sanitised_content")]
+        public Dictionary<string, Dictionary<string, string>> sanitisedContent;
 
         public override bool Equals(object response)
         {
@@ -38,5 +42,4 @@ namespace Notify.Models.Responses
         [JsonProperty("one_click_unsubscribe_url")]
         public string oneClickUnsubscribeURL;
     }
-
 }


### PR DESCRIPTION
Add support for sanitiseContentFor to sendEmail endpoint, and add sanitisedContent field to the response object for that endpoint

This is so that users could protect their messages against malicious content injection.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - [x] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_net.md) https://github.com/alphagov/notifications-tech-docs/pull/336
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number (in `src/GovukNotify/GovukNotify.csproj`)
